### PR TITLE
23 July - PR 1 - create new component and copy necessary files

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -147,6 +147,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/scopeTree",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/search",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -1,0 +1,838 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as nls from 'vs/nls';
+import { URI } from 'vs/base/common/uri';
+import * as perf from 'vs/base/common/performance';
+import { IAction, WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification } from 'vs/base/common/actions';
+import { memoize } from 'vs/base/common/decorators';
+import { IFilesConfiguration, ExplorerFolderContext, FilesExplorerFocusedContext, ExplorerFocusedContext, ExplorerRootContext, ExplorerResourceReadonlyContext, IExplorerService, ExplorerResourceCut, ExplorerResourceMoveableToTrash, ExplorerCompressedFocusContext, ExplorerCompressedFirstFocusContext, ExplorerCompressedLastFocusContext, ExplorerResourceAvailableEditorIdsContext } from 'vs/workbench/contrib/files/common/files';
+import { NewFolderAction, NewFileAction, FileCopiedContext, RefreshExplorerView, CollapseExplorerView } from 'vs/workbench/contrib/files/browser/fileActions';
+import { toResource, SideBySideEditor } from 'vs/workbench/common/editor';
+import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
+import * as DOM from 'vs/base/browser/dom';
+import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
+import { ExplorerDecorationsProvider } from 'vs/workbench/contrib/files/browser/views/explorerDecorationsProvider';
+import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
+import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { ResourceContextKey } from 'vs/workbench/common/resources';
+import { IDecorationsService } from 'vs/workbench/services/decorations/browser/decorations';
+import { WorkbenchCompressibleAsyncDataTree } from 'vs/platform/list/browser/listService';
+import { DelayedDragHandler } from 'vs/base/browser/dnd';
+import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
+import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/viewPaneContainer';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { ExplorerDelegate, ExplorerDataSource, FilesRenderer, ICompressedNavigationController, FilesFilter, FileSorter, FileDragAndDrop, ExplorerCompressionDelegate, isCompressedFolderName } from 'vs/workbench/contrib/files/browser/views/explorerViewer';
+import { IThemeService, IFileIconTheme } from 'vs/platform/theme/common/themeService';
+import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
+import { ITreeContextMenuEvent } from 'vs/base/browser/ui/tree/tree';
+import { IMenuService, MenuId, IMenu } from 'vs/platform/actions/common/actions';
+import { createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { ExplorerItem, NewExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
+import { ResourceLabels } from 'vs/workbench/browser/labels';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
+import { IAsyncDataTreeViewState } from 'vs/base/browser/ui/tree/asyncDataTree';
+import { FuzzyScore } from 'vs/base/common/filters';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { withNullAsUndefined } from 'vs/base/common/types';
+import { IFileService, FileSystemProviderCapabilities } from 'vs/platform/files/common/files';
+import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
+import { Event } from 'vs/base/common/event';
+import { attachStyler, IColorMapping } from 'vs/platform/theme/common/styler';
+import { ColorValue, listDropBackground } from 'vs/platform/theme/common/colorRegistry';
+import { Color } from 'vs/base/common/color';
+import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
+import { IViewDescriptorService } from 'vs/workbench/common/views';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
+
+interface IExplorerViewColors extends IColorMapping {
+	listDropBackground?: ColorValue | undefined;
+}
+
+interface IExplorerViewStyles {
+	listDropBackground?: Color;
+}
+
+function hasExpandedRootChild(tree: WorkbenchCompressibleAsyncDataTree<ExplorerItem | ExplorerItem[], ExplorerItem, FuzzyScore>, treeInput: ExplorerItem[]): boolean {
+	for (const folder of treeInput) {
+		if (tree.hasNode(folder) && !tree.isCollapsed(folder)) {
+			for (const [, child] of folder.children.entries()) {
+				if (tree.hasNode(child) && !tree.isCollapsed(child)) {
+					return true;
+				}
+			}
+		}
+	}
+
+	return false;
+}
+
+export function getContext(focus: ExplorerItem[], selection: ExplorerItem[], respectMultiSelection: boolean,
+	compressedNavigationControllerProvider: { getCompressedNavigationController(stat: ExplorerItem): ICompressedNavigationController | undefined }): ExplorerItem[] {
+
+	let focusedStat: ExplorerItem | undefined;
+	focusedStat = focus.length ? focus[0] : undefined;
+
+	const compressedNavigationController = focusedStat && compressedNavigationControllerProvider.getCompressedNavigationController(focusedStat);
+	focusedStat = compressedNavigationController ? compressedNavigationController.current : focusedStat;
+
+	const selectedStats: ExplorerItem[] = [];
+
+	for (const stat of selection) {
+		const controller = compressedNavigationControllerProvider.getCompressedNavigationController(stat);
+		if (controller && focusedStat && controller === compressedNavigationController) {
+			if (stat === focusedStat) {
+				selectedStats.push(stat);
+			}
+			// Ignore stats which are selected but are part of the same compact node as the focused stat
+			continue;
+		}
+
+		if (controller) {
+			selectedStats.push(...controller.items);
+		} else {
+			selectedStats.push(stat);
+		}
+	}
+	if (!focusedStat) {
+		if (respectMultiSelection) {
+			return selectedStats;
+		} else {
+			return [];
+		}
+	}
+
+	if (respectMultiSelection && selectedStats.indexOf(focusedStat) >= 0) {
+		return selectedStats;
+	}
+
+	return [focusedStat];
+}
+
+export class ExplorerView extends ViewPane {
+	static readonly TREE_VIEW_STATE_STORAGE_KEY: string = 'workbench.explorer.treeViewState';
+
+	private tree!: WorkbenchCompressibleAsyncDataTree<ExplorerItem | ExplorerItem[], ExplorerItem, FuzzyScore>;
+	private filter!: FilesFilter;
+
+	private resourceContext: ResourceContextKey;
+	private folderContext: IContextKey<boolean>;
+	private readonlyContext: IContextKey<boolean>;
+	private availableEditorIdsContext: IContextKey<string>;
+
+	private rootContext: IContextKey<boolean>;
+	private resourceMoveableToTrash: IContextKey<boolean>;
+
+	private renderer!: FilesRenderer;
+
+	private styleElement!: HTMLStyleElement;
+	private treeContainer!: HTMLElement;
+	private compressedFocusContext: IContextKey<boolean>;
+	private compressedFocusFirstContext: IContextKey<boolean>;
+	private compressedFocusLastContext: IContextKey<boolean>;
+
+	private horizontalScrolling: boolean | undefined;
+
+	// Refresh is needed on the initial explorer open
+	private shouldRefresh = true;
+	private dragHandler!: DelayedDragHandler;
+	private autoReveal: boolean | 'focusNoScroll' = false;
+	private actions: IAction[] | undefined;
+	private decorationsProvider: ExplorerDecorationsProvider | undefined;
+
+	constructor(
+		options: IViewPaneOptions,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
+		@IProgressService private readonly progressService: IProgressService,
+		@IEditorService private readonly editorService: IEditorService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IDecorationsService private readonly decorationService: IDecorationsService,
+		@ILabelService private readonly labelService: ILabelService,
+		@IThemeService protected themeService: IWorkbenchThemeService,
+		@IMenuService private readonly menuService: IMenuService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IExplorerService private readonly explorerService: IExplorerService,
+		@IStorageService private readonly storageService: IStorageService,
+		@IClipboardService private clipboardService: IClipboardService,
+		@IFileService private readonly fileService: IFileService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
+		@IOpenerService openerService: IOpenerService,
+	) {
+		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
+
+		this.resourceContext = instantiationService.createInstance(ResourceContextKey);
+		this._register(this.resourceContext);
+
+		this.folderContext = ExplorerFolderContext.bindTo(contextKeyService);
+		this.readonlyContext = ExplorerResourceReadonlyContext.bindTo(contextKeyService);
+		this.availableEditorIdsContext = ExplorerResourceAvailableEditorIdsContext.bindTo(contextKeyService);
+		this.rootContext = ExplorerRootContext.bindTo(contextKeyService);
+		this.resourceMoveableToTrash = ExplorerResourceMoveableToTrash.bindTo(contextKeyService);
+		this.compressedFocusContext = ExplorerCompressedFocusContext.bindTo(contextKeyService);
+		this.compressedFocusFirstContext = ExplorerCompressedFirstFocusContext.bindTo(contextKeyService);
+		this.compressedFocusLastContext = ExplorerCompressedLastFocusContext.bindTo(contextKeyService);
+
+		this.explorerService.registerView(this);
+	}
+
+	get name(): string {
+		return this.labelService.getWorkspaceLabel(this.contextService.getWorkspace());
+	}
+
+	get title(): string {
+		return this.name;
+	}
+
+	set title(_: string) {
+		// noop
+	}
+
+	// Memoized locals
+	@memoize private get contributedContextMenu(): IMenu {
+		const contributedContextMenu = this.menuService.createMenu(MenuId.ExplorerContext, this.tree.contextKeyService);
+		this._register(contributedContextMenu);
+		return contributedContextMenu;
+	}
+
+	@memoize private get fileCopiedContextKey(): IContextKey<boolean> {
+		return FileCopiedContext.bindTo(this.contextKeyService);
+	}
+
+	@memoize private get resourceCutContextKey(): IContextKey<boolean> {
+		return ExplorerResourceCut.bindTo(this.contextKeyService);
+	}
+
+	// Split view methods
+
+	protected renderHeader(container: HTMLElement): void {
+		super.renderHeader(container);
+
+		// Expand on drag over
+		this.dragHandler = new DelayedDragHandler(container, () => this.setExpanded(true));
+
+		const titleElement = container.querySelector('.title') as HTMLElement;
+		const setHeader = () => {
+			const workspace = this.contextService.getWorkspace();
+			const title = workspace.folders.map(folder => folder.name).join();
+			titleElement.textContent = this.name;
+			titleElement.title = title;
+			titleElement.setAttribute('aria-label', nls.localize('explorerSection', "Explorer Section: {0}", this.name));
+		};
+
+		this._register(this.contextService.onDidChangeWorkspaceName(setHeader));
+		this._register(this.labelService.onDidChangeFormatters(setHeader));
+		setHeader();
+	}
+
+	protected layoutBody(height: number, width: number): void {
+		super.layoutBody(height, width);
+		this.tree.layout(height, width);
+	}
+
+	renderBody(container: HTMLElement): void {
+		super.renderBody(container);
+
+		this.treeContainer = DOM.append(container, DOM.$('.explorer-folders-view'));
+
+		this.styleElement = DOM.createStyleSheet(this.treeContainer);
+		attachStyler<IExplorerViewColors>(this.themeService, { listDropBackground }, this.styleListDropBackground.bind(this));
+
+		this.createTree(this.treeContainer);
+
+		this._register(this.labelService.onDidChangeFormatters(() => {
+			this._onDidChangeTitleArea.fire();
+		}));
+
+		// Update configuration
+		const configuration = this.configurationService.getValue<IFilesConfiguration>();
+		this.onConfigurationUpdated(configuration);
+
+		// When the explorer viewer is loaded, listen to changes to the editor input
+		this._register(this.editorService.onDidActiveEditorChange(() => {
+			this.selectActiveFile(true);
+		}));
+
+		// Also handle configuration updates
+		this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationUpdated(this.configurationService.getValue<IFilesConfiguration>(), e)));
+
+		this._register(this.onDidChangeBodyVisibility(async visible => {
+			if (visible) {
+				// If a refresh was requested and we are now visible, run it
+				if (this.shouldRefresh) {
+					this.shouldRefresh = false;
+					await this.setTreeInput();
+				}
+				// Find resource to focus from active editor input if set
+				this.selectActiveFile(false, true);
+			}
+		}));
+	}
+
+	getActions(): IAction[] {
+		if (!this.actions) {
+			this.actions = [
+				this.instantiationService.createInstance(NewFileAction),
+				this.instantiationService.createInstance(NewFolderAction),
+				this.instantiationService.createInstance(RefreshExplorerView, RefreshExplorerView.ID, RefreshExplorerView.LABEL),
+				this.instantiationService.createInstance(CollapseExplorerView, CollapseExplorerView.ID, CollapseExplorerView.LABEL)
+			];
+			this.actions.forEach(a => this._register(a));
+		}
+		return this.actions;
+	}
+
+	focus(): void {
+		this.tree.domFocus();
+
+		const focused = this.tree.getFocus();
+		if (focused.length === 1 && this.autoReveal) {
+			this.tree.reveal(focused[0], 0.5);
+		}
+	}
+
+	getContext(respectMultiSelection: boolean): ExplorerItem[] {
+		return getContext(this.tree.getFocus(), this.tree.getSelection(), respectMultiSelection, this.renderer);
+	}
+
+	async setEditable(stat: ExplorerItem, isEditing: boolean): Promise<void> {
+		if (isEditing) {
+			this.horizontalScrolling = this.tree.options.horizontalScrolling;
+
+			if (this.horizontalScrolling) {
+				this.tree.updateOptions({ horizontalScrolling: false });
+			}
+
+			await this.tree.expand(stat.parent!);
+		} else {
+			if (this.horizontalScrolling !== undefined) {
+				this.tree.updateOptions({ horizontalScrolling: this.horizontalScrolling });
+			}
+
+			this.horizontalScrolling = undefined;
+			DOM.removeClass(this.treeContainer, 'highlight');
+		}
+
+		await this.refresh(false, stat.parent, false);
+
+		if (isEditing) {
+			DOM.addClass(this.treeContainer, 'highlight');
+			this.tree.reveal(stat);
+		} else {
+			this.tree.domFocus();
+		}
+	}
+
+	private selectActiveFile(deselect?: boolean, reveal = this.autoReveal): void {
+		if (this.autoReveal) {
+			const activeFile = this.getActiveFile();
+			if (activeFile) {
+				const focus = this.tree.getFocus();
+				if (focus.length === 1 && focus[0].resource.toString() === activeFile.toString()) {
+					// No action needed, active file is already focused
+					return;
+				}
+				this.explorerService.select(activeFile, reveal);
+			} else if (deselect) {
+				this.tree.setSelection([]);
+				this.tree.setFocus([]);
+			}
+		}
+	}
+
+	private createTree(container: HTMLElement): void {
+		this.filter = this.instantiationService.createInstance(FilesFilter);
+		this._register(this.filter);
+		this._register(this.filter.onDidChange(() => this.refresh(true)));
+		const explorerLabels = this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this.onDidChangeBodyVisibility });
+		this._register(explorerLabels);
+
+		const updateWidth = (stat: ExplorerItem) => this.tree.updateWidth(stat);
+		this.renderer = this.instantiationService.createInstance(FilesRenderer, explorerLabels, updateWidth);
+		this._register(this.renderer);
+
+		this._register(createFileIconThemableTreeContainerScope(container, this.themeService));
+
+		const isCompressionEnabled = () => this.configurationService.getValue<boolean>('explorer.compactFolders');
+
+		this.tree = <WorkbenchCompressibleAsyncDataTree<ExplorerItem | ExplorerItem[], ExplorerItem, FuzzyScore>>this.instantiationService.createInstance(WorkbenchCompressibleAsyncDataTree, 'FileExplorer', container, new ExplorerDelegate(), new ExplorerCompressionDelegate(), [this.renderer],
+			this.instantiationService.createInstance(ExplorerDataSource), {
+			compressionEnabled: isCompressionEnabled(),
+			accessibilityProvider: this.renderer,
+			identityProvider: {
+				getId: (stat: ExplorerItem) => {
+					if (stat instanceof NewExplorerItem) {
+						return `new:${stat.resource}`;
+					}
+
+					return stat.resource;
+				}
+			},
+			keyboardNavigationLabelProvider: {
+				getKeyboardNavigationLabel: (stat: ExplorerItem) => {
+					if (this.explorerService.isEditable(stat)) {
+						return undefined;
+					}
+
+					return stat.name;
+				},
+				getCompressedNodeKeyboardNavigationLabel: (stats: ExplorerItem[]) => {
+					if (stats.some(stat => this.explorerService.isEditable(stat))) {
+						return undefined;
+					}
+
+					return stats.map(stat => stat.name).join('/');
+				}
+			},
+			multipleSelectionSupport: true,
+			filter: this.filter,
+			sorter: this.instantiationService.createInstance(FileSorter),
+			dnd: this.instantiationService.createInstance(FileDragAndDrop),
+			autoExpandSingleChildren: true,
+			additionalScrollHeight: ExplorerDelegate.ITEM_HEIGHT,
+			overrideStyles: {
+				listBackground: SIDE_BAR_BACKGROUND
+			}
+		});
+		this._register(this.tree);
+
+		// Bind configuration
+		const onDidChangeCompressionConfiguration = Event.filter(this.configurationService.onDidChangeConfiguration, e => e.affectsConfiguration('explorer.compactFolders'));
+		this._register(onDidChangeCompressionConfiguration(_ => this.tree.updateOptions({ compressionEnabled: isCompressionEnabled() })));
+
+		// Bind context keys
+		FilesExplorerFocusedContext.bindTo(this.tree.contextKeyService);
+		ExplorerFocusedContext.bindTo(this.tree.contextKeyService);
+
+		// Update resource context based on focused element
+		this._register(this.tree.onDidChangeFocus(e => this.onFocusChanged(e.elements)));
+		this.onFocusChanged([]);
+		// Open when selecting via keyboard
+		this._register(this.tree.onDidOpen(async e => {
+			const element = e.element;
+			if (!element) {
+				return;
+			}
+			// Do not react if the user is expanding selection via keyboard.
+			// Check if the item was previously also selected, if yes the user is simply expanding / collapsing current selection #66589.
+			const shiftDown = e.browserEvent instanceof KeyboardEvent && e.browserEvent.shiftKey;
+			if (!shiftDown) {
+				if (element.isDirectory || this.explorerService.isEditable(undefined)) {
+					// Do not react if user is clicking on explorer items while some are being edited #70276
+					// Do not react if clicking on directories
+					return;
+				}
+				this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: 'workbench.files.openFile', from: 'explorer' });
+				await this.editorService.openEditor({ resource: element.resource, options: { preserveFocus: e.editorOptions.preserveFocus, pinned: e.editorOptions.pinned } }, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP);
+			}
+		}));
+
+		this._register(this.tree.onContextMenu(e => this.onContextMenu(e)));
+
+		this._register(this.tree.onDidScroll(async e => {
+			let editable = this.explorerService.getEditable();
+			if (e.scrollTopChanged && editable && this.tree.getRelativeTop(editable.stat) === null) {
+				await editable.data.onFinish('', false);
+			}
+		}));
+
+		this._register(this.tree.onDidChangeCollapseState(e => {
+			const element = e.node.element?.element;
+			if (element) {
+				const navigationController = this.renderer.getCompressedNavigationController(element instanceof Array ? element[0] : element);
+				if (navigationController) {
+					navigationController.updateCollapsed(e.node.collapsed);
+				}
+			}
+		}));
+
+		// save view state
+		this._register(this.storageService.onWillSaveState(() => {
+			this.storageService.store(ExplorerView.TREE_VIEW_STATE_STORAGE_KEY, JSON.stringify(this.tree.getViewState()), StorageScope.WORKSPACE);
+		}));
+	}
+
+	// React on events
+
+	private onConfigurationUpdated(configuration: IFilesConfiguration, event?: IConfigurationChangeEvent): void {
+		this.autoReveal = configuration?.explorer?.autoReveal;
+
+		// Push down config updates to components of viewer
+		if (event && (event.affectsConfiguration('explorer.decorations.colors') || event.affectsConfiguration('explorer.decorations.badges'))) {
+			this.refresh(true);
+		}
+	}
+
+	private setContextKeys(stat: ExplorerItem | null | undefined): void {
+		const isSingleFolder = this.contextService.getWorkbenchState() === WorkbenchState.FOLDER;
+		const resource = stat ? stat.resource : isSingleFolder ? this.contextService.getWorkspace().folders[0].uri : null;
+		this.resourceContext.set(resource);
+		this.folderContext.set((isSingleFolder && !stat) || !!stat && stat.isDirectory);
+		this.readonlyContext.set(!!stat && stat.isReadonly);
+		this.rootContext.set(!stat || (stat && stat.isRoot));
+
+		if (resource) {
+			const overrides = resource ? this.editorService.getEditorOverrides(resource, undefined, undefined) : [];
+			this.availableEditorIdsContext.set(overrides.map(([, entry]) => entry.id).join(','));
+		} else {
+			this.availableEditorIdsContext.reset();
+		}
+	}
+
+	private async onContextMenu(e: ITreeContextMenuEvent<ExplorerItem>): Promise<void> {
+		const disposables = new DisposableStore();
+		let stat = e.element;
+		let anchor = e.anchor;
+
+		// Compressed folders
+		if (stat) {
+			const controller = this.renderer.getCompressedNavigationController(stat);
+
+			if (controller) {
+				if (e.browserEvent instanceof KeyboardEvent || isCompressedFolderName(e.browserEvent.target)) {
+					anchor = controller.labels[controller.index];
+				} else {
+					controller.last();
+				}
+			}
+		}
+
+		// update dynamic contexts
+		this.fileCopiedContextKey.set(await this.clipboardService.hasResources());
+		this.setContextKeys(stat);
+
+		const selection = this.tree.getSelection();
+
+		const actions: IAction[] = [];
+		const roots = this.explorerService.roots; // If the click is outside of the elements pass the root resource if there is only one root. If there are multiple roots pass empty object.
+		let arg: URI | {};
+		if (stat instanceof ExplorerItem) {
+			const compressedController = this.renderer.getCompressedNavigationController(stat);
+			arg = compressedController ? compressedController.current.resource : stat.resource;
+		} else {
+			arg = roots.length === 1 ? roots[0].resource : {};
+		}
+		disposables.add(createAndFillInContextMenuActions(this.contributedContextMenu, { arg, shouldForwardArgs: true }, actions, this.contextMenuService));
+
+		this.contextMenuService.showContextMenu({
+			getAnchor: () => anchor,
+			getActions: () => actions,
+			onHide: (wasCancelled?: boolean) => {
+				if (wasCancelled) {
+					this.tree.domFocus();
+				}
+
+				disposables.dispose();
+			},
+			getActionsContext: () => stat && selection && selection.indexOf(stat) >= 0
+				? selection.map((fs: ExplorerItem) => fs.resource)
+				: stat instanceof ExplorerItem ? [stat.resource] : []
+		});
+	}
+
+	private onFocusChanged(elements: ExplorerItem[]): void {
+		const stat = elements && elements.length ? elements[0] : undefined;
+		this.setContextKeys(stat);
+
+		if (stat) {
+			const enableTrash = this.configurationService.getValue<IFilesConfiguration>().files.enableTrash;
+			const hasCapability = this.fileService.hasCapability(stat.resource, FileSystemProviderCapabilities.Trash);
+			this.resourceMoveableToTrash.set(enableTrash && hasCapability);
+		} else {
+			this.resourceMoveableToTrash.reset();
+		}
+
+		const compressedNavigationController = stat && this.renderer.getCompressedNavigationController(stat);
+
+		if (!compressedNavigationController) {
+			this.compressedFocusContext.set(false);
+			return;
+		}
+
+		this.compressedFocusContext.set(true);
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
+	}
+
+	// General methods
+
+	/**
+	 * Refresh the contents of the explorer to get up to date data from the disk about the file structure.
+	 * If the item is passed we refresh only that level of the tree, otherwise we do a full refresh.
+	 */
+	refresh(recursive: boolean, item?: ExplorerItem, cancelEditing: boolean = true): Promise<void> {
+		if (!this.tree || !this.isBodyVisible() || (item && !this.tree.hasNode(item))) {
+			// Tree node doesn't exist yet
+			this.shouldRefresh = true;
+			return Promise.resolve(undefined);
+		}
+
+		if (cancelEditing && this.explorerService.isEditable(undefined)) {
+			this.tree.domFocus();
+		}
+
+		const toRefresh = item || this.tree.getInput();
+		return this.tree.updateChildren(toRefresh, recursive);
+	}
+
+	getOptimalWidth(): number {
+		const parentNode = this.tree.getHTMLElement();
+		const childNodes = ([] as HTMLElement[]).slice.call(parentNode.querySelectorAll('.explorer-item .label-name')); // select all file labels
+
+		return DOM.getLargestChildWidth(parentNode, childNodes);
+	}
+
+	async setTreeInput(): Promise<void> {
+		if (!this.isBodyVisible()) {
+			this.shouldRefresh = true;
+			return Promise.resolve(undefined);
+		}
+
+		const initialInputSetup = !this.tree.getInput();
+		if (initialInputSetup) {
+			perf.mark('willResolveExplorer');
+		}
+		const roots = this.explorerService.roots;
+		let input: ExplorerItem | ExplorerItem[] = roots[0];
+		if (this.contextService.getWorkbenchState() !== WorkbenchState.FOLDER || roots[0].isError) {
+			// Display roots only when multi folder workspace
+			input = roots;
+		}
+
+		let viewState: IAsyncDataTreeViewState | undefined;
+		if (this.tree && this.tree.getInput()) {
+			viewState = this.tree.getViewState();
+		} else {
+			const rawViewState = this.storageService.get(ExplorerView.TREE_VIEW_STATE_STORAGE_KEY, StorageScope.WORKSPACE);
+			if (rawViewState) {
+				viewState = JSON.parse(rawViewState);
+			}
+		}
+
+		const previousInput = this.tree.getInput();
+		const promise = this.tree.setInput(input, viewState).then(() => {
+			if (Array.isArray(input)) {
+				if (!viewState || previousInput instanceof ExplorerItem) {
+					// There is no view state for this workspace, expand all roots. Or we transitioned from a folder workspace.
+					input.forEach(async item => {
+						try {
+							await this.tree.expand(item);
+						} catch (e) { }
+					});
+				}
+				if (Array.isArray(previousInput) && previousInput.length < input.length) {
+					// Roots added to the explorer -> expand them.
+					input.slice(previousInput.length).forEach(async item => {
+						try {
+							await this.tree.expand(item);
+						} catch (e) { }
+					});
+				}
+			}
+			if (initialInputSetup) {
+				perf.mark('didResolveExplorer');
+			}
+		});
+
+		this.progressService.withProgress({
+			location: ProgressLocation.Explorer,
+			delay: this.layoutService.isRestored() ? 800 : 1200 // less ugly initial startup
+		}, _progress => promise);
+
+		await promise;
+		if (!this.decorationsProvider) {
+			this.decorationsProvider = new ExplorerDecorationsProvider(this.explorerService, this.contextService);
+			this._register(this.decorationService.registerDecorationsProvider(this.decorationsProvider));
+		}
+	}
+
+	private getActiveFile(): URI | undefined {
+		const input = this.editorService.activeEditor;
+
+		// ignore diff editor inputs (helps to get out of diffing when returning to explorer)
+		if (input instanceof DiffEditorInput) {
+			return undefined;
+		}
+
+		// check for files
+		return withNullAsUndefined(toResource(input, { supportSideBySide: SideBySideEditor.PRIMARY }));
+	}
+
+	public async selectResource(resource: URI | undefined, reveal = this.autoReveal, retry = 0): Promise<void> {
+		// do no retry more than once to prevent inifinite loops in cases of inconsistent model
+		if (retry === 2) {
+			return;
+		}
+
+		if (!resource || !this.isBodyVisible()) {
+			return;
+		}
+
+		// Expand all stats in the parent chain.
+		let item: ExplorerItem | undefined = this.explorerService.roots.filter(i => this.uriIdentityService.extUri.isEqualOrParent(resource, i.resource))
+			// Take the root that is the closest to the stat #72299
+			.sort((first, second) => second.resource.path.length - first.resource.path.length)[0];
+
+		while (item && item.resource.toString() !== resource.toString()) {
+			try {
+				await this.tree.expand(item);
+			} catch (e) {
+				return this.selectResource(resource, reveal, retry + 1);
+			}
+
+			for (let child of item.children.values()) {
+				if (this.uriIdentityService.extUri.isEqualOrParent(resource, child.resource)) {
+					item = child;
+					break;
+				}
+				item = undefined;
+			}
+		}
+
+		if (item) {
+			if (item === this.tree.getInput()) {
+				this.tree.setFocus([]);
+				this.tree.setSelection([]);
+				return;
+			}
+
+			try {
+				if (reveal === true && this.tree.getRelativeTop(item) === null) {
+					// Don't scroll to the item if it's already visible, or if set not to.
+					this.tree.reveal(item, 0.5);
+				}
+
+				this.tree.setFocus([item]);
+				this.tree.setSelection([item]);
+			} catch (e) {
+				// Element might not be in the tree, try again and silently fail
+				return this.selectResource(resource, reveal, retry + 1);
+			}
+		}
+	}
+
+	itemsCopied(stats: ExplorerItem[], cut: boolean, previousCut: ExplorerItem[] | undefined): void {
+		this.fileCopiedContextKey.set(stats.length > 0);
+		this.resourceCutContextKey.set(cut && stats.length > 0);
+		if (previousCut) {
+			previousCut.forEach(item => this.tree.rerender(item));
+		}
+		if (cut) {
+			stats.forEach(s => this.tree.rerender(s));
+		}
+	}
+
+	collapseAll(): void {
+		if (this.explorerService.isEditable(undefined)) {
+			this.tree.domFocus();
+		}
+
+		const treeInput = this.tree.getInput();
+		if (Array.isArray(treeInput)) {
+			if (hasExpandedRootChild(this.tree, treeInput)) {
+				treeInput.forEach(folder => {
+					folder.children.forEach(child => this.tree.hasNode(child) && this.tree.collapse(child, true));
+				});
+
+				return;
+			}
+		}
+
+		this.tree.collapseAll();
+	}
+
+	previousCompressedStat(): void {
+		const focused = this.tree.getFocus();
+		if (!focused.length) {
+			return;
+		}
+
+		const compressedNavigationController = this.renderer.getCompressedNavigationController(focused[0])!;
+		compressedNavigationController.previous();
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
+	}
+
+	nextCompressedStat(): void {
+		const focused = this.tree.getFocus();
+		if (!focused.length) {
+			return;
+		}
+
+		const compressedNavigationController = this.renderer.getCompressedNavigationController(focused[0])!;
+		compressedNavigationController.next();
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
+	}
+
+	firstCompressedStat(): void {
+		const focused = this.tree.getFocus();
+		if (!focused.length) {
+			return;
+		}
+
+		const compressedNavigationController = this.renderer.getCompressedNavigationController(focused[0])!;
+		compressedNavigationController.first();
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
+	}
+
+	lastCompressedStat(): void {
+		const focused = this.tree.getFocus();
+		if (!focused.length) {
+			return;
+		}
+
+		const compressedNavigationController = this.renderer.getCompressedNavigationController(focused[0])!;
+		compressedNavigationController.last();
+		this.updateCompressedNavigationContextKeys(compressedNavigationController);
+	}
+
+	private updateCompressedNavigationContextKeys(controller: ICompressedNavigationController): void {
+		this.compressedFocusFirstContext.set(controller.index === 0);
+		this.compressedFocusLastContext.set(controller.index === controller.count - 1);
+	}
+
+	styleListDropBackground(styles: IExplorerViewStyles): void {
+		const content: string[] = [];
+
+		if (styles.listDropBackground) {
+			content.push(`.explorer-viewlet .explorer-item .monaco-icon-name-container.multiple > .label-name.drop-target > .monaco-highlighted-label { background-color: ${styles.listDropBackground}; }`);
+		}
+
+		const newStyles = content.join('\n');
+		if (newStyles !== this.styleElement.innerHTML) {
+			this.styleElement.innerHTML = newStyles;
+		}
+	}
+
+	dispose(): void {
+		if (this.dragHandler) {
+			this.dragHandler.dispose();
+		}
+		super.dispose();
+	}
+}
+
+function createFileIconThemableTreeContainerScope(container: HTMLElement, themeService: IThemeService): IDisposable {
+	DOM.addClass(container, 'file-icon-themable-tree');
+	DOM.addClass(container, 'show-file-icons');
+
+	const onDidChangeFileIconTheme = (theme: IFileIconTheme) => {
+		DOM.toggleClass(container, 'align-icons-and-twisties', theme.hasFileIcons && !theme.hasFolderIcons);
+		DOM.toggleClass(container, 'hide-arrows', theme.hidesExplorerArrows === true);
+	};
+
+	onDidChangeFileIconTheme(themeService.getFileIconTheme());
+	return themeService.onDidFileIconThemeChange(onDidChangeFileIconTheme);
+}

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
@@ -1,0 +1,1484 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
+import * as DOM from 'vs/base/browser/dom';
+import * as glob from 'vs/base/common/glob';
+import { IListVirtualDelegate, ListDragOverEffect } from 'vs/base/browser/ui/list/list';
+import { IProgressService, ProgressLocation, IProgressStep, IProgress } from 'vs/platform/progress/common/progress';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { IFileService, FileKind, FileOperationError, FileOperationResult, FileSystemProviderCapabilities, BinarySize } from 'vs/platform/files/common/files';
+import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
+import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
+import { IDisposable, Disposable, dispose, toDisposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { KeyCode } from 'vs/base/common/keyCodes';
+import { IFileLabelOptions, IResourceLabel, ResourceLabels } from 'vs/workbench/browser/labels';
+import { ITreeNode, ITreeFilter, TreeVisibility, TreeFilterResult, IAsyncDataSource, ITreeSorter, ITreeDragAndDrop, ITreeDragOverReaction, TreeDragOverBubble } from 'vs/base/browser/ui/tree/tree';
+import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
+import { IFilesConfiguration, IExplorerService, VIEW_ID } from 'vs/workbench/contrib/files/common/files';
+import { dirname, joinPath, isEqualOrParent, basename, distinctParents } from 'vs/base/common/resources';
+import { InputBox, MessageType } from 'vs/base/browser/ui/inputbox/inputBox';
+import { localize } from 'vs/nls';
+import { attachInputBoxStyler } from 'vs/platform/theme/common/styler';
+import { once } from 'vs/base/common/functional';
+import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { equals, deepClone } from 'vs/base/common/objects';
+import * as path from 'vs/base/common/path';
+import { ExplorerItem, NewExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
+import { compareFileExtensionsNumeric, compareFileNamesNumeric } from 'vs/base/common/comparers';
+import { fillResourceDataTransfers, CodeDataTransfers, extractResources, containsDragType } from 'vs/workbench/browser/dnd';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IDragAndDropData, DataTransfers } from 'vs/base/browser/dnd';
+import { Schemas } from 'vs/base/common/network';
+import { DesktopDragAndDropData, ExternalElementsDragAndDropData, ElementsDragAndDropData } from 'vs/base/browser/ui/list/listView';
+import { isMacintosh, isWeb } from 'vs/base/common/platform';
+import { IDialogService, IConfirmation, getFileNamesMessage } from 'vs/platform/dialogs/common/dialogs';
+import { IWorkingCopyFileService } from 'vs/workbench/services/workingCopy/common/workingCopyFileService';
+import { IHostService } from 'vs/workbench/services/host/browser/host';
+import { IWorkspaceEditingService } from 'vs/workbench/services/workspaces/common/workspaceEditing';
+import { URI } from 'vs/base/common/uri';
+import { ITask, sequence } from 'vs/base/common/async';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IWorkspaceFolderCreationData } from 'vs/platform/workspaces/common/workspaces';
+import { findValidPasteFileTarget } from 'vs/workbench/contrib/files/browser/fileActions';
+import { FuzzyScore, createMatches } from 'vs/base/common/filters';
+import { Emitter, Event, EventMultiplexer } from 'vs/base/common/event';
+import { ITreeCompressionDelegate } from 'vs/base/browser/ui/tree/asyncDataTree';
+import { ICompressibleTreeRenderer } from 'vs/base/browser/ui/tree/objectTree';
+import { ICompressedTreeNode } from 'vs/base/browser/ui/tree/compressedObjectTreeModel';
+import { VSBuffer, newWriteableBufferStream } from 'vs/base/common/buffer';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { isNumber } from 'vs/base/common/types';
+import { domEvent } from 'vs/base/browser/event';
+import { IEditableData } from 'vs/workbench/common/views';
+import { IEditorInput } from 'vs/workbench/common/editor';
+import { CancellationTokenSource, CancellationToken } from 'vs/base/common/cancellation';
+
+export class ExplorerDelegate implements IListVirtualDelegate<ExplorerItem> {
+
+	static readonly ITEM_HEIGHT = 22;
+
+	getHeight(element: ExplorerItem): number {
+		return ExplorerDelegate.ITEM_HEIGHT;
+	}
+
+	getTemplateId(element: ExplorerItem): string {
+		return FilesRenderer.ID;
+	}
+}
+
+export const explorerRootErrorEmitter = new Emitter<URI>();
+export class ExplorerDataSource implements IAsyncDataSource<ExplorerItem | ExplorerItem[], ExplorerItem> {
+
+	constructor(
+		@IProgressService private readonly progressService: IProgressService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
+		@IFileService private readonly fileService: IFileService,
+		@IExplorerService private readonly explorerService: IExplorerService,
+		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService
+	) { }
+
+	hasChildren(element: ExplorerItem | ExplorerItem[]): boolean {
+		return Array.isArray(element) || element.isDirectory;
+	}
+
+	getChildren(element: ExplorerItem | ExplorerItem[]): Promise<ExplorerItem[]> {
+		if (Array.isArray(element)) {
+			return Promise.resolve(element);
+		}
+
+		const sortOrder = this.explorerService.sortOrder;
+		const promise = element.fetchChildren(sortOrder).then(undefined, e => {
+
+			if (element instanceof ExplorerItem && element.isRoot) {
+				if (this.contextService.getWorkbenchState() === WorkbenchState.FOLDER) {
+					// Single folder create a dummy explorer item to show error
+					const placeholder = new ExplorerItem(element.resource, this.fileService, undefined, false);
+					placeholder.isError = true;
+					return [placeholder];
+				} else {
+					explorerRootErrorEmitter.fire(element.resource);
+				}
+			} else {
+				// Do not show error for roots since we already use an explorer decoration to notify user
+				this.notificationService.error(e);
+			}
+
+			return []; // we could not resolve any children because of an error
+		});
+
+		this.progressService.withProgress({
+			location: ProgressLocation.Explorer,
+			delay: this.layoutService.isRestored() ? 800 : 1200 // less ugly initial startup
+		}, _progress => promise);
+
+		return promise;
+	}
+}
+
+export interface ICompressedNavigationController {
+	readonly current: ExplorerItem;
+	readonly currentId: string;
+	readonly items: ExplorerItem[];
+	readonly labels: HTMLElement[];
+	readonly index: number;
+	readonly count: number;
+	readonly onDidChange: Event<void>;
+	previous(): void;
+	next(): void;
+	first(): void;
+	last(): void;
+	setIndex(index: number): void;
+	updateCollapsed(collapsed: boolean): void;
+}
+
+export class CompressedNavigationController implements ICompressedNavigationController, IDisposable {
+
+	static ID = 0;
+
+	private _index: number;
+	private _labels!: HTMLElement[];
+	private _updateLabelDisposable: IDisposable;
+
+	get index(): number { return this._index; }
+	get count(): number { return this.items.length; }
+	get current(): ExplorerItem { return this.items[this._index]!; }
+	get currentId(): string { return `${this.id}_${this.index}`; }
+	get labels(): HTMLElement[] { return this._labels; }
+
+	private _onDidChange = new Emitter<void>();
+	readonly onDidChange = this._onDidChange.event;
+
+	constructor(private id: string, readonly items: ExplorerItem[], templateData: IFileTemplateData, private depth: number, private collapsed: boolean) {
+		this._index = items.length - 1;
+
+		this.updateLabels(templateData);
+		this._updateLabelDisposable = templateData.label.onDidRender(() => this.updateLabels(templateData));
+	}
+
+	private updateLabels(templateData: IFileTemplateData): void {
+		this._labels = Array.from(templateData.container.querySelectorAll('.label-name')) as HTMLElement[];
+
+		for (let i = 0; i < this.labels.length; i++) {
+			this.labels[i].setAttribute('aria-label', this.items[i].name);
+			this.labels[i].setAttribute('aria-level', `${this.depth + i}`);
+		}
+		this.updateCollapsed(this.collapsed);
+
+		if (this._index < this.labels.length) {
+			DOM.addClass(this.labels[this._index], 'active');
+		}
+	}
+
+	previous(): void {
+		if (this._index <= 0) {
+			return;
+		}
+
+		this.setIndex(this._index - 1);
+	}
+
+	next(): void {
+		if (this._index >= this.items.length - 1) {
+			return;
+		}
+
+		this.setIndex(this._index + 1);
+	}
+
+	first(): void {
+		if (this._index === 0) {
+			return;
+		}
+
+		this.setIndex(0);
+	}
+
+	last(): void {
+		if (this._index === this.items.length - 1) {
+			return;
+		}
+
+		this.setIndex(this.items.length - 1);
+	}
+
+	setIndex(index: number): void {
+		if (index < 0 || index >= this.items.length) {
+			return;
+		}
+
+		DOM.removeClass(this.labels[this._index], 'active');
+		this._index = index;
+		DOM.addClass(this.labels[this._index], 'active');
+
+		this._onDidChange.fire();
+	}
+
+	updateCollapsed(collapsed: boolean): void {
+		this.collapsed = collapsed;
+		for (let i = 0; i < this.labels.length; i++) {
+			this.labels[i].setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+		}
+	}
+
+	dispose(): void {
+		this._onDidChange.dispose();
+		this._updateLabelDisposable.dispose();
+	}
+}
+
+export interface IFileTemplateData {
+	elementDisposable: IDisposable;
+	label: IResourceLabel;
+	container: HTMLElement;
+}
+
+export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, FuzzyScore, IFileTemplateData>, IListAccessibilityProvider<ExplorerItem>, IDisposable {
+	static readonly ID = 'file';
+
+	private config: IFilesConfiguration;
+	private configListener: IDisposable;
+	private compressedNavigationControllers = new Map<ExplorerItem, CompressedNavigationController>();
+
+	private _onDidChangeActiveDescendant = new EventMultiplexer<void>();
+	readonly onDidChangeActiveDescendant = this._onDidChangeActiveDescendant.event;
+
+	constructor(
+		private labels: ResourceLabels,
+		private updateWidth: (stat: ExplorerItem) => void,
+		@IContextViewService private readonly contextViewService: IContextViewService,
+		@IThemeService private readonly themeService: IThemeService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IExplorerService private readonly explorerService: IExplorerService,
+		@ILabelService private readonly labelService: ILabelService
+	) {
+		this.config = this.configurationService.getValue<IFilesConfiguration>();
+		this.configListener = this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('explorer')) {
+				this.config = this.configurationService.getValue();
+			}
+		});
+	}
+
+	getWidgetAriaLabel(): string {
+		return localize('treeAriaLabel', "Files Explorer");
+	}
+
+	get templateId(): string {
+		return FilesRenderer.ID;
+	}
+
+	renderTemplate(container: HTMLElement): IFileTemplateData {
+		const elementDisposable = Disposable.None;
+		const label = this.labels.create(container, { supportHighlights: true });
+
+		return { elementDisposable, label, container };
+	}
+
+	renderElement(node: ITreeNode<ExplorerItem, FuzzyScore>, index: number, templateData: IFileTemplateData): void {
+		templateData.elementDisposable.dispose();
+		const stat = node.element;
+		const editableData = this.explorerService.getEditableData(stat);
+
+		DOM.removeClass(templateData.label.element, 'compressed');
+
+		// File Label
+		if (!editableData) {
+			templateData.label.element.style.display = 'flex';
+			templateData.elementDisposable = this.renderStat(stat, stat.name, undefined, node.filterData, templateData);
+		}
+
+		// Input Box
+		else {
+			templateData.label.element.style.display = 'none';
+			templateData.elementDisposable = this.renderInputBox(templateData.container, stat, editableData);
+		}
+	}
+
+	renderCompressedElements(node: ITreeNode<ICompressedTreeNode<ExplorerItem>, FuzzyScore>, index: number, templateData: IFileTemplateData, height: number | undefined): void {
+		templateData.elementDisposable.dispose();
+
+		const stat = node.element.elements[node.element.elements.length - 1];
+		const editable = node.element.elements.filter(e => this.explorerService.isEditable(e));
+		const editableData = editable.length === 0 ? undefined : this.explorerService.getEditableData(editable[0]);
+
+		// File Label
+		if (!editableData) {
+			DOM.addClass(templateData.label.element, 'compressed');
+			templateData.label.element.style.display = 'flex';
+
+			const disposables = new DisposableStore();
+			const id = `compressed-explorer_${CompressedNavigationController.ID++}`;
+
+			const label = node.element.elements.map(e => e.name);
+			disposables.add(this.renderStat(stat, label, id, node.filterData, templateData));
+
+			const compressedNavigationController = new CompressedNavigationController(id, node.element.elements, templateData, node.depth, node.collapsed);
+			disposables.add(compressedNavigationController);
+			this.compressedNavigationControllers.set(stat, compressedNavigationController);
+
+			// accessibility
+			disposables.add(this._onDidChangeActiveDescendant.add(compressedNavigationController.onDidChange));
+
+			domEvent(templateData.container, 'mousedown')(e => {
+				const result = getIconLabelNameFromHTMLElement(e.target);
+
+				if (result) {
+					compressedNavigationController.setIndex(result.index);
+				}
+			}, undefined, disposables);
+
+			disposables.add(toDisposable(() => this.compressedNavigationControllers.delete(stat)));
+
+			templateData.elementDisposable = disposables;
+		}
+
+		// Input Box
+		else {
+			DOM.removeClass(templateData.label.element, 'compressed');
+			templateData.label.element.style.display = 'none';
+			templateData.elementDisposable = this.renderInputBox(templateData.container, editable[0], editableData);
+		}
+	}
+
+	private renderStat(stat: ExplorerItem, label: string | string[], domId: string | undefined, filterData: FuzzyScore | undefined, templateData: IFileTemplateData): IDisposable {
+		templateData.label.element.style.display = 'flex';
+		const extraClasses = ['explorer-item'];
+		if (this.explorerService.isCut(stat)) {
+			extraClasses.push('cut');
+		}
+
+		templateData.label.setResource({ resource: stat.resource, name: label }, {
+			fileKind: stat.isRoot ? FileKind.ROOT_FOLDER : stat.isDirectory ? FileKind.FOLDER : FileKind.FILE,
+			extraClasses,
+			fileDecorations: this.config.explorer.decorations,
+			matches: createMatches(filterData),
+			separator: this.labelService.getSeparator(stat.resource.scheme, stat.resource.authority),
+			domId
+		});
+
+		return templateData.label.onDidRender(() => {
+			try {
+				this.updateWidth(stat);
+			} catch (e) {
+				// noop since the element might no longer be in the tree, no update of width necessery
+			}
+		});
+	}
+
+	private renderInputBox(container: HTMLElement, stat: ExplorerItem, editableData: IEditableData): IDisposable {
+
+		// Use a file label only for the icon next to the input box
+		const label = this.labels.create(container);
+		const extraClasses = ['explorer-item', 'explorer-item-edited'];
+		const fileKind = stat.isRoot ? FileKind.ROOT_FOLDER : stat.isDirectory ? FileKind.FOLDER : FileKind.FILE;
+		const labelOptions: IFileLabelOptions = { hidePath: true, hideLabel: true, fileKind, extraClasses };
+
+		const parent = stat.name ? dirname(stat.resource) : stat.resource;
+		const value = stat.name || '';
+
+		label.setFile(joinPath(parent, value || ' '), labelOptions); // Use icon for ' ' if name is empty.
+
+		// hack: hide label
+		(label.element.firstElementChild as HTMLElement).style.display = 'none';
+
+		// Input field for name
+		const inputBox = new InputBox(label.element, this.contextViewService, {
+			validationOptions: {
+				validation: (value) => {
+					const message = editableData.validationMessage(value);
+					if (!message || message.severity !== Severity.Error) {
+						return null;
+					}
+
+					return {
+						content: message.content,
+						formatContent: true,
+						type: MessageType.ERROR
+					};
+				}
+			},
+			ariaLabel: localize('fileInputAriaLabel', "Type file name. Press Enter to confirm or Escape to cancel.")
+		});
+		const styler = attachInputBoxStyler(inputBox, this.themeService);
+
+		const lastDot = value.lastIndexOf('.');
+
+		inputBox.value = value;
+		inputBox.focus();
+		inputBox.select({ start: 0, end: lastDot > 0 && !stat.isDirectory ? lastDot : value.length });
+
+		const done = once((success: boolean, finishEditing: boolean) => {
+			label.element.style.display = 'none';
+			const value = inputBox.value;
+			dispose(toDispose);
+			label.element.remove();
+			if (finishEditing) {
+				editableData.onFinish(value, success);
+			}
+		});
+
+		const showInputBoxNotification = () => {
+			if (inputBox.isInputValid()) {
+				const message = editableData.validationMessage(inputBox.value);
+				if (message) {
+					inputBox.showMessage({
+						content: message.content,
+						formatContent: true,
+						type: message.severity === Severity.Info ? MessageType.INFO : message.severity === Severity.Warning ? MessageType.WARNING : MessageType.ERROR
+					});
+				} else {
+					inputBox.hideMessage();
+				}
+			}
+		};
+		showInputBoxNotification();
+
+		const toDispose = [
+			inputBox,
+			inputBox.onDidChange(value => {
+				label.setFile(joinPath(parent, value || ' '), labelOptions); // update label icon while typing!
+			}),
+			DOM.addStandardDisposableListener(inputBox.inputElement, DOM.EventType.KEY_DOWN, (e: IKeyboardEvent) => {
+				if (e.equals(KeyCode.Enter)) {
+					if (inputBox.validate()) {
+						done(true, true);
+					}
+				} else if (e.equals(KeyCode.Escape)) {
+					done(false, true);
+				}
+			}),
+			DOM.addStandardDisposableListener(inputBox.inputElement, DOM.EventType.KEY_UP, (e: IKeyboardEvent) => {
+				showInputBoxNotification();
+			}),
+			DOM.addDisposableListener(inputBox.inputElement, DOM.EventType.BLUR, () => {
+				done(inputBox.isInputValid(), true);
+			}),
+			label,
+			styler
+		];
+
+		return toDisposable(() => {
+			done(false, false);
+		});
+	}
+
+	disposeElement(element: ITreeNode<ExplorerItem, FuzzyScore>, index: number, templateData: IFileTemplateData): void {
+		templateData.elementDisposable.dispose();
+	}
+
+	disposeCompressedElements(node: ITreeNode<ICompressedTreeNode<ExplorerItem>, FuzzyScore>, index: number, templateData: IFileTemplateData): void {
+		templateData.elementDisposable.dispose();
+	}
+
+	disposeTemplate(templateData: IFileTemplateData): void {
+		templateData.elementDisposable.dispose();
+		templateData.label.dispose();
+	}
+
+	getCompressedNavigationController(stat: ExplorerItem): ICompressedNavigationController | undefined {
+		return this.compressedNavigationControllers.get(stat);
+	}
+
+	// IAccessibilityProvider
+
+	getAriaLabel(element: ExplorerItem): string {
+		return element.name;
+	}
+
+	getActiveDescendantId(stat: ExplorerItem): string | undefined {
+		const compressedNavigationController = this.compressedNavigationControllers.get(stat);
+		return compressedNavigationController?.currentId;
+	}
+
+	dispose(): void {
+		this.configListener.dispose();
+	}
+}
+
+interface CachedParsedExpression {
+	original: glob.IExpression;
+	parsed: glob.ParsedExpression;
+}
+
+/**
+ * Respectes files.exclude setting in filtering out content from the explorer.
+ * Makes sure that visible editors are always shown in the explorer even if they are filtered out by settings.
+ */
+export class FilesFilter implements ITreeFilter<ExplorerItem, FuzzyScore> {
+	private hiddenExpressionPerRoot: Map<string, CachedParsedExpression>;
+	private hiddenUris = new Set<URI>();
+	private editorsAffectingFilter = new Set<IEditorInput>();
+	private _onDidChange = new Emitter<void>();
+	private toDispose: IDisposable[] = [];
+
+	constructor(
+		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IExplorerService private readonly explorerService: IExplorerService,
+		@IEditorService private readonly editorService: IEditorService,
+	) {
+		this.hiddenExpressionPerRoot = new Map<string, CachedParsedExpression>();
+		this.toDispose.push(this.contextService.onDidChangeWorkspaceFolders(() => this.updateConfiguration()));
+		this.toDispose.push(this.configurationService.onDidChangeConfiguration((e) => {
+			if (e.affectsConfiguration('files.exclude')) {
+				this.updateConfiguration();
+			}
+		}));
+		this.toDispose.push(this.editorService.onDidVisibleEditorsChange(() => {
+			const editors = this.editorService.visibleEditors;
+			let shouldFire = false;
+			this.hiddenUris.forEach(u => {
+				editors.forEach(e => {
+					if (e.resource && isEqualOrParent(e.resource, u)) {
+						// A filtered resource suddenly became visible since user opened an editor
+						shouldFire = true;
+					}
+				});
+			});
+
+			this.editorsAffectingFilter.forEach(e => {
+				if (!editors.includes(e)) {
+					// Editor that was affecting filtering is no longer visible
+					shouldFire = true;
+				}
+			});
+			if (shouldFire) {
+				this.editorsAffectingFilter.clear();
+				this.hiddenUris.clear();
+				this._onDidChange.fire();
+			}
+		}));
+		this.updateConfiguration();
+	}
+
+	get onDidChange(): Event<void> {
+		return this._onDidChange.event;
+	}
+
+	private updateConfiguration(): void {
+		let shouldFire = false;
+		this.contextService.getWorkspace().folders.forEach(folder => {
+			const configuration = this.configurationService.getValue<IFilesConfiguration>({ resource: folder.uri });
+			const excludesConfig: glob.IExpression = configuration?.files?.exclude || Object.create(null);
+
+			if (!shouldFire) {
+				const cached = this.hiddenExpressionPerRoot.get(folder.uri.toString());
+				shouldFire = !cached || !equals(cached.original, excludesConfig);
+			}
+
+			const excludesConfigCopy = deepClone(excludesConfig); // do not keep the config, as it gets mutated under our hoods
+
+			this.hiddenExpressionPerRoot.set(folder.uri.toString(), { original: excludesConfigCopy, parsed: glob.parse(excludesConfigCopy) });
+		});
+
+		if (shouldFire) {
+			this.editorsAffectingFilter.clear();
+			this.hiddenUris.clear();
+			this._onDidChange.fire();
+		}
+	}
+
+	filter(stat: ExplorerItem, parentVisibility: TreeVisibility): TreeFilterResult<FuzzyScore> {
+		const isVisible = this.isVisible(stat, parentVisibility);
+		if (isVisible) {
+			this.hiddenUris.delete(stat.resource);
+		} else {
+			this.hiddenUris.add(stat.resource);
+		}
+
+		return isVisible;
+	}
+
+	private isVisible(stat: ExplorerItem, parentVisibility: TreeVisibility): boolean {
+		stat.isExcluded = false;
+		if (parentVisibility === TreeVisibility.Hidden) {
+			stat.isExcluded = true;
+			return false;
+		}
+		if (this.explorerService.getEditableData(stat) || stat.isRoot) {
+			return true; // always visible
+		}
+
+		// Hide those that match Hidden Patterns
+		const cached = this.hiddenExpressionPerRoot.get(stat.root.resource.toString());
+		if ((cached && cached.parsed(path.relative(stat.root.resource.path, stat.resource.path), stat.name, name => !!(stat.parent && stat.parent.getChild(name)))) || stat.parent?.isExcluded) {
+			stat.isExcluded = true;
+			const editors = this.editorService.visibleEditors;
+			const editor = editors.find(e => e.resource && isEqualOrParent(e.resource, stat.resource));
+			if (editor) {
+				this.editorsAffectingFilter.add(editor);
+				return true; // Show all opened files and their parents
+			}
+
+			return false; // hidden through pattern
+		}
+
+		return true;
+	}
+
+	dispose(): void {
+		dispose(this.toDispose);
+	}
+}
+
+// Explorer Sorter
+export class FileSorter implements ITreeSorter<ExplorerItem> {
+
+	constructor(
+		@IExplorerService private readonly explorerService: IExplorerService,
+		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService
+	) { }
+
+	compare(statA: ExplorerItem, statB: ExplorerItem): number {
+		// Do not sort roots
+		if (statA.isRoot) {
+			if (statB.isRoot) {
+				const workspaceA = this.contextService.getWorkspaceFolder(statA.resource);
+				const workspaceB = this.contextService.getWorkspaceFolder(statB.resource);
+				return workspaceA && workspaceB ? (workspaceA.index - workspaceB.index) : -1;
+			}
+
+			return -1;
+		}
+
+		if (statB.isRoot) {
+			return 1;
+		}
+
+		const sortOrder = this.explorerService.sortOrder;
+
+		// Sort Directories
+		switch (sortOrder) {
+			case 'type':
+				if (statA.isDirectory && !statB.isDirectory) {
+					return -1;
+				}
+
+				if (statB.isDirectory && !statA.isDirectory) {
+					return 1;
+				}
+
+				if (statA.isDirectory && statB.isDirectory) {
+					return compareFileNamesNumeric(statA.name, statB.name);
+				}
+
+				break;
+
+			case 'filesFirst':
+				if (statA.isDirectory && !statB.isDirectory) {
+					return 1;
+				}
+
+				if (statB.isDirectory && !statA.isDirectory) {
+					return -1;
+				}
+
+				break;
+
+			case 'mixed':
+				break; // not sorting when "mixed" is on
+
+			default: /* 'default', 'modified' */
+				if (statA.isDirectory && !statB.isDirectory) {
+					return -1;
+				}
+
+				if (statB.isDirectory && !statA.isDirectory) {
+					return 1;
+				}
+
+				break;
+		}
+
+		// Sort Files
+		switch (sortOrder) {
+			case 'type':
+				return compareFileExtensionsNumeric(statA.name, statB.name);
+
+			case 'modified':
+				if (statA.mtime !== statB.mtime) {
+					return (statA.mtime && statB.mtime && statA.mtime < statB.mtime) ? 1 : -1;
+				}
+
+				return compareFileNamesNumeric(statA.name, statB.name);
+
+			default: /* 'default', 'mixed', 'filesFirst' */
+				return compareFileNamesNumeric(statA.name, statB.name);
+		}
+	}
+}
+
+function getFileOverwriteConfirm(name: string): IConfirmation {
+	return {
+		message: localize('confirmOverwrite', "A file or folder with the name '{0}' already exists in the destination folder. Do you want to replace it?", name),
+		detail: localize('irreversible', "This action is irreversible!"),
+		primaryButton: localize({ key: 'replaceButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Replace"),
+		type: 'warning'
+	};
+}
+
+function getMultipleFilesOverwriteConfirm(files: URI[]): IConfirmation {
+	if (files.length > 1) {
+		return {
+			message: localize('confirmManyOverwrites', "The following {0} files and/or folders already exist in the destination folder. Do you want to replace them?", files.length),
+			detail: getFileNamesMessage(files) + '\n' + localize('irreversible', "This action is irreversible!"),
+			primaryButton: localize({ key: 'replaceButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Replace"),
+			type: 'warning'
+		};
+	}
+
+	return getFileOverwriteConfirm(basename(files[0]));
+}
+
+interface IWebkitDataTransfer {
+	items: IWebkitDataTransferItem[];
+}
+
+interface IWebkitDataTransferItem {
+	webkitGetAsEntry(): IWebkitDataTransferItemEntry;
+}
+
+interface IWebkitDataTransferItemEntry {
+	name: string | undefined;
+	isFile: boolean;
+	isDirectory: boolean;
+
+	file(resolve: (file: File) => void, reject: () => void): void;
+	createReader(): IWebkitDataTransferItemEntryReader;
+}
+
+interface IWebkitDataTransferItemEntryReader {
+	readEntries(resolve: (file: IWebkitDataTransferItemEntry[]) => void, reject: () => void): void
+}
+
+interface IUploadOperation {
+	filesTotal: number;
+	filesUploaded: number;
+
+	startTime: number;
+	bytesUploaded: number;
+}
+
+export class FileDragAndDrop implements ITreeDragAndDrop<ExplorerItem> {
+	private static readonly CONFIRM_DND_SETTING_KEY = 'explorer.confirmDragAndDrop';
+
+	private compressedDragOverElement: HTMLElement | undefined;
+	private compressedDropTargetDisposable: IDisposable = Disposable.None;
+
+	private toDispose: IDisposable[];
+	private dropEnabled = false;
+
+	constructor(
+		@INotificationService private notificationService: INotificationService,
+		@IExplorerService private explorerService: IExplorerService,
+		@IEditorService private editorService: IEditorService,
+		@IDialogService private dialogService: IDialogService,
+		@IWorkspaceContextService private contextService: IWorkspaceContextService,
+		@IFileService private fileService: IFileService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@IInstantiationService private instantiationService: IInstantiationService,
+		@IWorkingCopyFileService private workingCopyFileService: IWorkingCopyFileService,
+		@IHostService private hostService: IHostService,
+		@IWorkspaceEditingService private workspaceEditingService: IWorkspaceEditingService,
+		@IProgressService private readonly progressService: IProgressService
+	) {
+		this.toDispose = [];
+
+		const updateDropEnablement = () => {
+			this.dropEnabled = this.configurationService.getValue('explorer.enableDragAndDrop');
+		};
+		updateDropEnablement();
+		this.toDispose.push(this.configurationService.onDidChangeConfiguration((e) => updateDropEnablement()));
+	}
+
+	onDragOver(data: IDragAndDropData, target: ExplorerItem | undefined, targetIndex: number | undefined, originalEvent: DragEvent): boolean | ITreeDragOverReaction {
+		if (!this.dropEnabled) {
+			return false;
+		}
+
+		// Compressed folders
+		if (target) {
+			const compressedTarget = FileDragAndDrop.getCompressedStatFromDragEvent(target, originalEvent);
+
+			if (compressedTarget) {
+				const iconLabelName = getIconLabelNameFromHTMLElement(originalEvent.target);
+
+				if (iconLabelName && iconLabelName.index < iconLabelName.count - 1) {
+					const result = this.handleDragOver(data, compressedTarget, targetIndex, originalEvent);
+
+					if (result) {
+						if (iconLabelName.element !== this.compressedDragOverElement) {
+							this.compressedDragOverElement = iconLabelName.element;
+							this.compressedDropTargetDisposable.dispose();
+							this.compressedDropTargetDisposable = toDisposable(() => {
+								DOM.removeClass(iconLabelName.element, 'drop-target');
+								this.compressedDragOverElement = undefined;
+							});
+
+							DOM.addClass(iconLabelName.element, 'drop-target');
+						}
+
+						return typeof result === 'boolean' ? result : { ...result, feedback: [] };
+					}
+
+					this.compressedDropTargetDisposable.dispose();
+					return false;
+				}
+			}
+		}
+
+		this.compressedDropTargetDisposable.dispose();
+		return this.handleDragOver(data, target, targetIndex, originalEvent);
+	}
+
+	private handleDragOver(data: IDragAndDropData, target: ExplorerItem | undefined, targetIndex: number | undefined, originalEvent: DragEvent): boolean | ITreeDragOverReaction {
+		const isCopy = originalEvent && ((originalEvent.ctrlKey && !isMacintosh) || (originalEvent.altKey && isMacintosh));
+		const fromDesktop = data instanceof DesktopDragAndDropData;
+		const effect = (fromDesktop || isCopy) ? ListDragOverEffect.Copy : ListDragOverEffect.Move;
+
+		// Desktop DND
+		if (fromDesktop) {
+			if (!containsDragType(originalEvent, DataTransfers.FILES, CodeDataTransfers.FILES)) {
+				return false;
+			}
+		}
+
+		// Other-Tree DND
+		else if (data instanceof ExternalElementsDragAndDropData) {
+			return false;
+		}
+
+		// In-Explorer DND
+		else {
+			const items = FileDragAndDrop.getStatsFromDragAndDropData(data as ElementsDragAndDropData<ExplorerItem, ExplorerItem[]>);
+
+			if (!target) {
+				// Dropping onto the empty area. Do not accept if items dragged are already
+				// children of the root unless we are copying the file
+				if (!isCopy && items.every(i => !!i.parent && i.parent.isRoot)) {
+					return false;
+				}
+
+				return { accept: true, bubble: TreeDragOverBubble.Down, effect, autoExpand: false };
+			}
+
+			if (!Array.isArray(items)) {
+				return false;
+			}
+
+			if (items.some((source) => {
+				if (source.isRoot && target instanceof ExplorerItem && !target.isRoot) {
+					return true; // Root folder can not be moved to a non root file stat.
+				}
+
+				if (source.resource.toString() === target.resource.toString()) {
+					return true; // Can not move anything onto itself
+				}
+
+				if (source.isRoot && target instanceof ExplorerItem && target.isRoot) {
+					// Disable moving workspace roots in one another
+					return false;
+				}
+
+				if (!isCopy && dirname(source.resource).toString() === target.resource.toString()) {
+					return true; // Can not move a file to the same parent unless we copy
+				}
+
+				if (isEqualOrParent(target.resource, source.resource)) {
+					return true; // Can not move a parent folder into one of its children
+				}
+
+				return false;
+			})) {
+				return false;
+			}
+		}
+
+		// All (target = model)
+		if (!target) {
+			return { accept: true, bubble: TreeDragOverBubble.Down, effect };
+		}
+
+		// All (target = file/folder)
+		else {
+			if (target.isDirectory) {
+				if (target.isReadonly) {
+					return false;
+				}
+
+				return { accept: true, bubble: TreeDragOverBubble.Down, effect, autoExpand: true };
+			}
+
+			if (this.contextService.getWorkspace().folders.every(folder => folder.uri.toString() !== target.resource.toString())) {
+				return { accept: true, bubble: TreeDragOverBubble.Up, effect };
+			}
+		}
+
+		return false;
+	}
+
+	getDragURI(element: ExplorerItem): string | null {
+		if (this.explorerService.isEditable(element)) {
+			return null;
+		}
+
+		return element.resource.toString();
+	}
+
+	getDragLabel(elements: ExplorerItem[], originalEvent: DragEvent): string | undefined {
+		if (elements.length === 1) {
+			const stat = FileDragAndDrop.getCompressedStatFromDragEvent(elements[0], originalEvent);
+			return stat.name;
+		}
+
+		return String(elements.length);
+	}
+
+	onDragStart(data: IDragAndDropData, originalEvent: DragEvent): void {
+		const items = FileDragAndDrop.getStatsFromDragAndDropData(data as ElementsDragAndDropData<ExplorerItem, ExplorerItem[]>, originalEvent);
+		if (items && items.length && originalEvent.dataTransfer) {
+			// Apply some datatransfer types to allow for dragging the element outside of the application
+			this.instantiationService.invokeFunction(fillResourceDataTransfers, items, undefined, originalEvent);
+
+			// The only custom data transfer we set from the explorer is a file transfer
+			// to be able to DND between multiple code file explorers across windows
+			const fileResources = items.filter(s => !s.isDirectory && s.resource.scheme === Schemas.file).map(r => r.resource.fsPath);
+			if (fileResources.length) {
+				originalEvent.dataTransfer.setData(CodeDataTransfers.FILES, JSON.stringify(fileResources));
+			}
+		}
+	}
+
+	drop(data: IDragAndDropData, target: ExplorerItem | undefined, targetIndex: number | undefined, originalEvent: DragEvent): void {
+		this.compressedDropTargetDisposable.dispose();
+
+		// Find compressed target
+		if (target) {
+			const compressedTarget = FileDragAndDrop.getCompressedStatFromDragEvent(target, originalEvent);
+
+			if (compressedTarget) {
+				target = compressedTarget;
+			}
+		}
+
+		// Find parent to add to
+		if (!target) {
+			target = this.explorerService.roots[this.explorerService.roots.length - 1];
+		}
+		if (!target.isDirectory && target.parent) {
+			target = target.parent;
+		}
+		if (target.isReadonly) {
+			return;
+		}
+
+		// Desktop DND (Import file)
+		if (data instanceof DesktopDragAndDropData) {
+			if (isWeb) {
+				this.handleWebExternalDrop(data, target, originalEvent).then(undefined, e => this.notificationService.warn(e));
+			} else {
+				this.handleExternalDrop(data, target, originalEvent).then(undefined, e => this.notificationService.warn(e));
+			}
+		}
+		// In-Explorer DND (Move/Copy file)
+		else {
+			this.handleExplorerDrop(data as ElementsDragAndDropData<ExplorerItem, ExplorerItem[]>, target, originalEvent).then(undefined, e => this.notificationService.warn(e));
+		}
+	}
+
+	private async handleWebExternalDrop(data: DesktopDragAndDropData, target: ExplorerItem, originalEvent: DragEvent): Promise<void> {
+		const items = (originalEvent.dataTransfer as unknown as IWebkitDataTransfer).items;
+
+		// Somehow the items thing is being modified at random, maybe as a security
+		// measure since this is a DND operation. As such, we copy the items into
+		// an array we own as early as possible before using it.
+		const entries: IWebkitDataTransferItemEntry[] = [];
+		for (const item of items) {
+			entries.push(item.webkitGetAsEntry());
+		}
+
+		const results: { isFile: boolean, resource: URI }[] = [];
+		const cts = new CancellationTokenSource();
+		const operation: IUploadOperation = { filesTotal: entries.length, filesUploaded: 0, startTime: Date.now(), bytesUploaded: 0 };
+
+		// Start upload and report progress globally
+		const uploadPromise = this.progressService.withProgress({
+			location: ProgressLocation.Window,
+			delay: 800,
+			cancellable: true,
+			title: localize('uploadingFiles', "Uploading")
+		}, async progress => {
+			for (let entry of entries) {
+
+				// Confirm overwrite as needed
+				if (target && entry.name && target.getChild(entry.name)) {
+					const { confirmed } = await this.dialogService.confirm(getFileOverwriteConfirm(entry.name));
+					if (!confirmed) {
+						continue;
+					}
+
+					await this.workingCopyFileService.delete([joinPath(target.resource, entry.name)], { recursive: true });
+				}
+
+				// Upload entry
+				const result = await this.doUploadWebFileEntry(entry, target.resource, target, progress, operation, cts.token);
+				if (result) {
+					results.push(result);
+				}
+			}
+		}, () => cts.dispose(true));
+
+		// Also indicate progress in the files view
+		this.progressService.withProgress({ location: VIEW_ID, delay: 800 }, () => uploadPromise);
+
+		// Wait until upload is done
+		await uploadPromise;
+
+		// Open uploaded file in editor only if we upload just one
+		if (!cts.token.isCancellationRequested && results.length === 1 && results[0].isFile) {
+			await this.editorService.openEditor({ resource: results[0].resource, options: { pinned: true } });
+		}
+	}
+
+	private async doUploadWebFileEntry(entry: IWebkitDataTransferItemEntry, parentResource: URI, target: ExplorerItem | undefined, progress: IProgress<IProgressStep>, operation: IUploadOperation, token: CancellationToken): Promise<{ isFile: boolean, resource: URI } | undefined> {
+		if (token.isCancellationRequested || !entry.name || (!entry.isFile && !entry.isDirectory)) {
+			return undefined;
+		}
+
+		// Report progress
+		let fileBytesUploaded = 0;
+		const reportProgress = (fileSize: number, bytesUploaded: number): void => {
+			fileBytesUploaded += bytesUploaded;
+			operation.bytesUploaded += bytesUploaded;
+
+			const bytesUploadedPerSecond = operation.bytesUploaded / ((Date.now() - operation.startTime) / 1000);
+
+			let message: string;
+			if (operation.filesTotal === 1 && entry.name) {
+				message = entry.name;
+			} else {
+				message = localize('uploadProgress', "{0} of {1} files ({2}/s)", operation.filesUploaded, operation.filesTotal, BinarySize.formatSize(bytesUploadedPerSecond));
+			}
+
+			if (fileSize > BinarySize.MB) {
+				message = localize('uploadProgressDetail', "{0} ({1} of {2}, {3}/s)", message, BinarySize.formatSize(fileBytesUploaded), BinarySize.formatSize(fileSize), BinarySize.formatSize(bytesUploadedPerSecond));
+			}
+
+			progress.report({ message });
+		};
+		operation.filesUploaded++;
+		reportProgress(0, 0);
+
+		// Handle file upload
+		const resource = joinPath(parentResource, entry.name);
+		if (entry.isFile) {
+			const file = await new Promise<File>((resolve, reject) => entry.file(resolve, reject));
+
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+
+			// Chrome/Edge/Firefox support stream method
+			if (typeof file.stream === 'function') {
+				await this.doUploadWebFileEntryBuffered(resource, file, reportProgress, token);
+			}
+
+			// Fallback to unbuffered upload for other browsers
+			else {
+				await this.doUploadWebFileEntryUnbuffered(resource, file, reportProgress);
+			}
+
+			return { isFile: true, resource };
+		}
+
+		// Handle folder upload
+		else {
+
+			// Create target folder
+			await this.fileService.createFolder(resource);
+
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+
+			// Recursive upload files in this directory
+			const dirReader = entry.createReader();
+			const childEntries: IWebkitDataTransferItemEntry[] = [];
+			let done = false;
+			do {
+				const childEntriesChunk = await new Promise<IWebkitDataTransferItemEntry[]>((resolve, reject) => dirReader.readEntries(resolve, reject));
+				if (childEntriesChunk.length > 0) {
+					childEntries.push(...childEntriesChunk);
+				} else {
+					done = true; // an empty array is a signal that all entries have been read
+				}
+			} while (!done);
+
+			// Update operation total based on new counts
+			operation.filesTotal += childEntries.length;
+
+			// Upload all entries as files to target
+			const folderTarget = target && target.getChild(entry.name) || undefined;
+			for (let childEntry of childEntries) {
+				await this.doUploadWebFileEntry(childEntry, resource, folderTarget, progress, operation, token);
+			}
+
+			return { isFile: false, resource };
+		}
+	}
+
+	private async doUploadWebFileEntryBuffered(resource: URI, file: File, progressReporter: (fileSize: number, bytesUploaded: number) => void, token: CancellationToken): Promise<void> {
+		const writeableStream = newWriteableBufferStream({
+			// Set a highWaterMark to prevent the stream
+			// for file upload to produce large buffers
+			// in-memory
+			highWaterMark: 10
+		});
+		const writeFilePromise = this.fileService.writeFile(resource, writeableStream);
+
+		// Read the file in chunks using File.stream() web APIs
+		try {
+			const reader: ReadableStreamDefaultReader<Uint8Array> = file.stream().getReader();
+
+			let res = await reader.read();
+			while (!res.done) {
+				if (token.isCancellationRequested) {
+					return undefined;
+				}
+
+				// Write buffer into stream but make sure to wait
+				// in case the highWaterMark is reached
+				const buffer = VSBuffer.wrap(res.value);
+				await writeableStream.write(buffer);
+
+				if (token.isCancellationRequested) {
+					return undefined;
+				}
+
+				// Report progress
+				progressReporter(file.size, buffer.byteLength);
+
+				res = await reader.read();
+			}
+			writeableStream.end(res.value instanceof Uint8Array ? VSBuffer.wrap(res.value) : undefined);
+		} catch (error) {
+			writeableStream.end(error);
+		}
+
+		if (token.isCancellationRequested) {
+			return undefined;
+		}
+
+		// Wait for file being written to target
+		await writeFilePromise;
+	}
+
+	private doUploadWebFileEntryUnbuffered(resource: URI, file: File, progressReporter: (fileSize: number, bytesUploaded: number) => void): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			const reader = new FileReader();
+			reader.onload = async event => {
+				try {
+					if (event.target?.result instanceof ArrayBuffer) {
+						const buffer = VSBuffer.wrap(new Uint8Array(event.target.result));
+						await this.fileService.writeFile(resource, buffer);
+
+						// Report progress
+						progressReporter(file.size, buffer.byteLength);
+					} else {
+						throw new Error('Could not read from dropped file.');
+					}
+
+					resolve();
+				} catch (error) {
+					reject(error);
+				}
+			};
+
+			// Start reading the file to trigger `onload`
+			reader.readAsArrayBuffer(file);
+		});
+	}
+
+	private async handleExternalDrop(data: DesktopDragAndDropData, target: ExplorerItem, originalEvent: DragEvent): Promise<void> {
+
+		// Check for dropped external files to be folders
+		const droppedResources = extractResources(originalEvent, true);
+		const result = await this.fileService.resolveAll(droppedResources.map(droppedResource => ({ resource: droppedResource.resource })));
+
+		// Pass focus to window
+		this.hostService.focus();
+
+		// Handle folders by adding to workspace if we are in workspace context
+		const folders = result.filter(r => r.success && r.stat && r.stat.isDirectory).map(result => ({ uri: result.stat!.resource }));
+		if (folders.length > 0) {
+			const buttons = [
+				folders.length > 1 ? localize('copyFolders', "&&Copy Folders") : localize('copyFolder', "&&Copy Folder"),
+				localize('cancel', "Cancel")
+			];
+			const workspaceFolderSchemas = this.contextService.getWorkspace().folders.map(f => f.uri.scheme);
+			let message = folders.length > 1 ? localize('copyfolders', "Are you sure to want to copy folders?") : localize('copyfolder', "Are you sure to want to copy '{0}'?", basename(folders[0].uri));
+			if (folders.some(f => workspaceFolderSchemas.indexOf(f.uri.scheme) >= 0)) {
+				// We only allow to add a folder to the workspace if there is already a workspace folder with that scheme
+				buttons.unshift(folders.length > 1 ? localize('addFolders', "&&Add Folders to Workspace") : localize('addFolder', "&&Add Folder to Workspace"));
+				message = folders.length > 1 ? localize('dropFolders', "Do you want to copy the folders or add the folders to the workspace?")
+					: localize('dropFolder', "Do you want to copy '{0}' or add '{0}' as a folder to the workspace?", basename(folders[0].uri));
+			}
+
+			const { choice } = await this.dialogService.show(Severity.Info, message, buttons);
+			if (choice === buttons.length - 3) {
+				return this.workspaceEditingService.addFolders(folders);
+			}
+			if (choice === buttons.length - 2) {
+				return this.addResources(target, droppedResources.map(res => res.resource));
+			}
+
+			return undefined;
+		}
+
+		// Handle dropped files (only support FileStat as target)
+		else if (target instanceof ExplorerItem) {
+			return this.addResources(target, droppedResources.map(res => res.resource));
+		}
+	}
+
+	private async addResources(target: ExplorerItem, resources: URI[]): Promise<void> {
+		if (resources && resources.length > 0) {
+
+			// Resolve target to check for name collisions and ask user
+			const targetStat = await this.fileService.resolve(target.resource);
+
+			// Check for name collisions
+			const targetNames = new Set<string>();
+			const caseSensitive = this.fileService.hasCapability(target.resource, FileSystemProviderCapabilities.PathCaseSensitive);
+			if (targetStat.children) {
+				targetStat.children.forEach(child => {
+					targetNames.add(caseSensitive ? child.name : child.name.toLowerCase());
+				});
+			}
+
+			// Run add in sequence
+			const addPromisesFactory: ITask<Promise<void>>[] = [];
+			await Promise.all(resources.map(async resource => {
+				if (targetNames.has(caseSensitive ? basename(resource) : basename(resource).toLowerCase())) {
+					const confirmationResult = await this.dialogService.confirm(getFileOverwriteConfirm(basename(resource)));
+					if (!confirmationResult.confirmed) {
+						return;
+					}
+				}
+
+				addPromisesFactory.push(async () => {
+					const sourceFile = resource;
+					const targetFile = joinPath(target.resource, basename(sourceFile));
+
+					const stat = (await this.workingCopyFileService.copy([{ source: sourceFile, target: targetFile }], { overwrite: true }))[0];
+					// if we only add one file, just open it directly
+					if (resources.length === 1 && !stat.isDirectory) {
+						this.editorService.openEditor({ resource: stat.resource, options: { pinned: true } });
+					}
+				});
+			}));
+
+			await sequence(addPromisesFactory);
+		}
+	}
+
+	private async handleExplorerDrop(data: ElementsDragAndDropData<ExplorerItem, ExplorerItem[]>, target: ExplorerItem, originalEvent: DragEvent): Promise<void> {
+		const elementsData = FileDragAndDrop.getStatsFromDragAndDropData(data);
+		const items = distinctParents(elementsData, s => s.resource);
+		const isCopy = (originalEvent.ctrlKey && !isMacintosh) || (originalEvent.altKey && isMacintosh);
+
+		// Handle confirm setting
+		const confirmDragAndDrop = !isCopy && this.configurationService.getValue<boolean>(FileDragAndDrop.CONFIRM_DND_SETTING_KEY);
+		if (confirmDragAndDrop) {
+			const message = items.length > 1 && items.every(s => s.isRoot) ? localize('confirmRootsMove', "Are you sure you want to change the order of multiple root folders in your workspace?")
+				: items.length > 1 ? localize('confirmMultiMove', "Are you sure you want to move the following {0} files into '{1}'?", items.length, target.name)
+					: items[0].isRoot ? localize('confirmRootMove', "Are you sure you want to change the order of root folder '{0}' in your workspace?", items[0].name)
+						: localize('confirmMove', "Are you sure you want to move '{0}' into '{1}'?", items[0].name, target.name);
+			const detail = items.length > 1 && !items.every(s => s.isRoot) ? getFileNamesMessage(items.map(i => i.resource)) : undefined;
+
+			const confirmation = await this.dialogService.confirm({
+				message,
+				detail,
+				checkbox: {
+					label: localize('doNotAskAgain', "Do not ask me again")
+				},
+				type: 'question',
+				primaryButton: localize({ key: 'moveButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Move")
+			});
+
+			if (!confirmation.confirmed) {
+				return;
+			}
+
+			// Check for confirmation checkbox
+			if (confirmation.checkboxChecked === true) {
+				await this.configurationService.updateValue(FileDragAndDrop.CONFIRM_DND_SETTING_KEY, false, ConfigurationTarget.USER);
+			}
+		}
+
+		await this.doHandleRootDrop(items.filter(s => s.isRoot), target);
+
+		const sources = items.filter(s => !s.isRoot);
+		if (isCopy) {
+			await this.doHandleExplorerDropOnCopy(sources, target);
+		} else {
+			return this.doHandleExplorerDropOnMove(sources, target);
+		}
+	}
+
+	private doHandleRootDrop(roots: ExplorerItem[], target: ExplorerItem): Promise<void> {
+		if (roots.length === 0) {
+			return Promise.resolve(undefined);
+		}
+
+		const folders = this.contextService.getWorkspace().folders;
+		let targetIndex: number | undefined;
+		const workspaceCreationData: IWorkspaceFolderCreationData[] = [];
+		const rootsToMove: IWorkspaceFolderCreationData[] = [];
+
+		for (let index = 0; index < folders.length; index++) {
+			const data = {
+				uri: folders[index].uri,
+				name: folders[index].name
+			};
+			if (target instanceof ExplorerItem && folders[index].uri.toString() === target.resource.toString()) {
+				targetIndex = index;
+			}
+
+			if (roots.every(r => r.resource.toString() !== folders[index].uri.toString())) {
+				workspaceCreationData.push(data);
+			} else {
+				rootsToMove.push(data);
+			}
+		}
+		if (targetIndex === undefined) {
+			targetIndex = workspaceCreationData.length;
+		}
+
+		workspaceCreationData.splice(targetIndex, 0, ...rootsToMove);
+		return this.workspaceEditingService.updateFolders(0, workspaceCreationData.length, workspaceCreationData);
+	}
+
+	private async doHandleExplorerDropOnCopy(sources: ExplorerItem[], target: ExplorerItem): Promise<void> {
+		// Reuse duplicate action when user copies
+		const incrementalNaming = this.configurationService.getValue<IFilesConfiguration>().explorer.incrementalNaming;
+		const sourceTargetPairs = sources.map(({ resource, isDirectory }) => ({ source: resource, target: findValidPasteFileTarget(this.explorerService, target, { resource, isDirectory, allowOverwrite: false }, incrementalNaming) }));
+		const stats = await this.workingCopyFileService.copy(sourceTargetPairs);
+		const editors = stats.filter(stat => !stat.isDirectory).map(({ resource }) => ({ resource, options: { pinned: true } }));
+
+		await this.editorService.openEditors(editors);
+	}
+
+	private async doHandleExplorerDropOnMove(sources: ExplorerItem[], target: ExplorerItem): Promise<void> {
+
+		// Do not allow moving readonly items
+		const sourceTargetPairs = sources.filter(source => !source.isReadonly).map(source => ({ source: source.resource, target: joinPath(target.resource, source.name) }));
+
+		try {
+			await this.workingCopyFileService.move(sourceTargetPairs);
+		} catch (error) {
+			// Conflict
+			if ((<FileOperationError>error).fileOperationResult === FileOperationResult.FILE_MOVE_CONFLICT) {
+
+				const overwrites: URI[] = [];
+				for (const { target } of sourceTargetPairs) {
+					if (await this.fileService.exists(target)) {
+						overwrites.push(target);
+					}
+				}
+
+				const confirm = getMultipleFilesOverwriteConfirm(overwrites);
+				// Move with overwrite if the user confirms
+				const { confirmed } = await this.dialogService.confirm(confirm);
+				if (confirmed) {
+					try {
+						await this.workingCopyFileService.move(sourceTargetPairs, { overwrite: true });
+					} catch (error) {
+						this.notificationService.error(error);
+					}
+				}
+			}
+			// Any other error
+			else {
+				this.notificationService.error(error);
+			}
+		}
+	}
+
+	private static getStatsFromDragAndDropData(data: ElementsDragAndDropData<ExplorerItem, ExplorerItem[]>, dragStartEvent?: DragEvent): ExplorerItem[] {
+		if (data.context) {
+			return data.context;
+		}
+
+		// Detect compressed folder dragging
+		if (dragStartEvent && data.elements.length === 1) {
+			data.context = [FileDragAndDrop.getCompressedStatFromDragEvent(data.elements[0], dragStartEvent)];
+			return data.context;
+		}
+
+		return data.elements;
+	}
+
+	private static getCompressedStatFromDragEvent(stat: ExplorerItem, dragEvent: DragEvent): ExplorerItem {
+		const target = document.elementFromPoint(dragEvent.clientX, dragEvent.clientY);
+		const iconLabelName = getIconLabelNameFromHTMLElement(target);
+
+		if (iconLabelName) {
+			const { count, index } = iconLabelName;
+
+			let i = count - 1;
+			while (i > index && stat.parent) {
+				stat = stat.parent;
+				i--;
+			}
+
+			return stat;
+		}
+
+		return stat;
+	}
+
+	onDragEnd(): void {
+		this.compressedDropTargetDisposable.dispose();
+	}
+}
+
+function getIconLabelNameFromHTMLElement(target: HTMLElement | EventTarget | Element | null): { element: HTMLElement, count: number, index: number } | null {
+	if (!(target instanceof HTMLElement)) {
+		return null;
+	}
+
+	let element: HTMLElement | null = target;
+
+	while (element && !DOM.hasClass(element, 'monaco-list-row')) {
+		if (DOM.hasClass(element, 'label-name') && element.hasAttribute('data-icon-label-count')) {
+			const count = Number(element.getAttribute('data-icon-label-count'));
+			const index = Number(element.getAttribute('data-icon-label-index'));
+
+			if (isNumber(count) && isNumber(index)) {
+				return { element: element, count, index };
+			}
+		}
+
+		element = element.parentElement;
+	}
+
+	return null;
+}
+
+export function isCompressedFolderName(target: HTMLElement | EventTarget | Element | null): boolean {
+	return !!getIconLabelNameFromHTMLElement(target);
+}
+
+export class ExplorerCompressionDelegate implements ITreeCompressionDelegate<ExplorerItem> {
+
+	isIncompressible(stat: ExplorerItem): boolean {
+		return stat.isRoot || !stat.isDirectory || stat instanceof NewExplorerItem || (!stat.parent || stat.parent.isRoot);
+	}
+}

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewlet.ts
@@ -1,0 +1,291 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import 'vs/css!./media/explorerviewlet';
+import { localize } from 'vs/nls';
+import * as DOM from 'vs/base/browser/dom';
+import { VIEWLET_ID, ExplorerViewletVisibleContext, IFilesConfiguration, OpenEditorsVisibleContext, VIEW_ID } from 'vs/workbench/contrib/files/common/files';
+import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
+import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
+import { ExplorerView } from 'vs/workbench/contrib/files/browser/views/explorerView';
+import { EmptyView } from 'vs/workbench/contrib/files/browser/views/emptyView';
+import { OpenEditorsView } from 'vs/workbench/contrib/files/browser/views/openEditorsView';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { IWorkspaceContextService, WorkbenchState } from 'vs/platform/workspace/common/workspace';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { IContextKeyService, IContextKey, ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IViewsRegistry, IViewDescriptor, Extensions, ViewContainer, IViewContainersRegistry, ViewContainerLocation, IViewDescriptorService } from 'vs/workbench/common/views';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
+import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
+import { DelegatingEditorService } from 'vs/workbench/services/editor/browser/editorService';
+import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IEditorPane } from 'vs/workbench/common/editor';
+import { ViewPane, ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneContainer';
+import { KeyChord, KeyMod, KeyCode } from 'vs/base/common/keyCodes';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { WorkbenchStateContext, RemoteNameContext } from 'vs/workbench/browser/contextkeys';
+import { IsWebContext } from 'vs/platform/contextkey/common/contextkeys';
+import { AddRootFolderAction, OpenFolderAction, OpenFileFolderAction } from 'vs/workbench/browser/actions/workspaceActions';
+import { isMacintosh } from 'vs/base/common/platform';
+import { Codicon } from 'vs/base/common/codicons';
+
+export class ExplorerViewletViewsContribution extends Disposable implements IWorkbenchContribution {
+
+	private openEditorsVisibleContextKey!: IContextKey<boolean>;
+
+	constructor(
+		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IProgressService progressService: IProgressService
+	) {
+		super();
+
+		progressService.withProgress({ location: ProgressLocation.Explorer }, () => workspaceContextService.getCompleteWorkspace()).finally(() => {
+			this.registerViews();
+
+			this.openEditorsVisibleContextKey = OpenEditorsVisibleContext.bindTo(contextKeyService);
+			this.updateOpenEditorsVisibility();
+
+			this._register(workspaceContextService.onDidChangeWorkbenchState(() => this.registerViews()));
+			this._register(workspaceContextService.onDidChangeWorkspaceFolders(() => this.registerViews()));
+			this._register(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationUpdated(e)));
+		});
+	}
+
+	private registerViews(): void {
+		const viewDescriptors = viewsRegistry.getViews(VIEW_CONTAINER);
+
+		let viewDescriptorsToRegister: IViewDescriptor[] = [];
+		let viewDescriptorsToDeregister: IViewDescriptor[] = [];
+
+		const openEditorsViewDescriptor = this.createOpenEditorsViewDescriptor();
+		if (!viewDescriptors.some(v => v.id === openEditorsViewDescriptor.id)) {
+			viewDescriptorsToRegister.push(openEditorsViewDescriptor);
+		}
+
+		const explorerViewDescriptor = this.createExplorerViewDescriptor();
+		const registeredExplorerViewDescriptor = viewDescriptors.find(v => v.id === explorerViewDescriptor.id);
+		const emptyViewDescriptor = this.createEmptyViewDescriptor();
+		const registeredEmptyViewDescriptor = viewDescriptors.find(v => v.id === emptyViewDescriptor.id);
+
+		if (this.workspaceContextService.getWorkbenchState() === WorkbenchState.EMPTY || this.workspaceContextService.getWorkspace().folders.length === 0) {
+			if (registeredExplorerViewDescriptor) {
+				viewDescriptorsToDeregister.push(registeredExplorerViewDescriptor);
+			}
+			if (!registeredEmptyViewDescriptor) {
+				viewDescriptorsToRegister.push(emptyViewDescriptor);
+			}
+		} else {
+			if (registeredEmptyViewDescriptor) {
+				viewDescriptorsToDeregister.push(registeredEmptyViewDescriptor);
+			}
+			if (!registeredExplorerViewDescriptor) {
+				viewDescriptorsToRegister.push(explorerViewDescriptor);
+			}
+		}
+
+		if (viewDescriptorsToRegister.length) {
+			viewsRegistry.registerViews(viewDescriptorsToRegister, VIEW_CONTAINER);
+		}
+		if (viewDescriptorsToDeregister.length) {
+			viewsRegistry.deregisterViews(viewDescriptorsToDeregister, VIEW_CONTAINER);
+		}
+	}
+
+	private createOpenEditorsViewDescriptor(): IViewDescriptor {
+		return {
+			id: OpenEditorsView.ID,
+			name: OpenEditorsView.NAME,
+			ctorDescriptor: new SyncDescriptor(OpenEditorsView),
+			containerIcon: 'codicon-files',
+			order: 0,
+			when: OpenEditorsVisibleContext,
+			canToggleVisibility: true,
+			canMoveView: true,
+			collapsed: true,
+			focusCommand: {
+				id: 'workbench.files.action.focusOpenEditorsView',
+				keybindings: { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KEY_K, KeyCode.KEY_E) }
+			}
+		};
+	}
+
+	private createEmptyViewDescriptor(): IViewDescriptor {
+		return {
+			id: EmptyView.ID,
+			name: EmptyView.NAME,
+			containerIcon: Codicon.files.classNames,
+			ctorDescriptor: new SyncDescriptor(EmptyView),
+			order: 1,
+			canToggleVisibility: true,
+			focusCommand: {
+				id: 'workbench.explorer.fileView.focus'
+			}
+		};
+	}
+
+	private createExplorerViewDescriptor(): IViewDescriptor {
+		return {
+			id: VIEW_ID,
+			name: localize('folders', "Folders"),
+			containerIcon: Codicon.files.classNames,
+			ctorDescriptor: new SyncDescriptor(ExplorerView),
+			order: 1,
+			canToggleVisibility: false,
+			focusCommand: {
+				id: 'workbench.explorer.fileView.focus'
+			}
+		};
+	}
+
+	private onConfigurationUpdated(e: IConfigurationChangeEvent): void {
+		if (e.affectsConfiguration('explorer.openEditors.visible')) {
+			this.updateOpenEditorsVisibility();
+		}
+	}
+
+	private updateOpenEditorsVisibility(): void {
+		this.openEditorsVisibleContextKey.set(this.workspaceContextService.getWorkbenchState() === WorkbenchState.EMPTY || this.configurationService.getValue('explorer.openEditors.visible') !== 0);
+	}
+}
+
+export class ExplorerViewPaneContainer extends ViewPaneContainer {
+
+	private viewletVisibleContextKey: IContextKey<boolean>;
+
+	constructor(
+		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IWorkspaceContextService protected contextService: IWorkspaceContextService,
+		@IStorageService protected storageService: IStorageService,
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IInstantiationService protected instantiationService: IInstantiationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IThemeService themeService: IThemeService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IExtensionService extensionService: IExtensionService,
+		@IViewDescriptorService viewDescriptorService: IViewDescriptorService
+	) {
+
+		super(VIEWLET_ID, { mergeViewWithContainerWhenSingleView: true }, instantiationService, configurationService, layoutService, contextMenuService, telemetryService, extensionService, themeService, storageService, contextService, viewDescriptorService);
+
+		this.viewletVisibleContextKey = ExplorerViewletVisibleContext.bindTo(contextKeyService);
+
+		this._register(this.contextService.onDidChangeWorkspaceName(e => this.updateTitleArea()));
+	}
+
+	create(parent: HTMLElement): void {
+		super.create(parent);
+		DOM.addClass(parent, 'explorer-viewlet');
+	}
+
+	protected createView(viewDescriptor: IViewDescriptor, options: IViewletViewOptions): ViewPane {
+		if (viewDescriptor.id === VIEW_ID) {
+			// Create a delegating editor service for the explorer to be able to delay the refresh in the opened
+			// editors view above. This is a workaround for being able to double click on a file to make it pinned
+			// without causing the animation in the opened editors view to kick in and change scroll position.
+			// We try to be smart and only use the delay if we recognize that the user action is likely to cause
+			// a new entry in the opened editors view.
+			const delegatingEditorService = this.instantiationService.createInstance(DelegatingEditorService, async (delegate, group, editor, options): Promise<IEditorPane | null> => {
+				let openEditorsView = this.getOpenEditorsView();
+				if (openEditorsView) {
+					let delay = 0;
+
+					const config = this.configurationService.getValue<IFilesConfiguration>();
+					const delayEditorOpeningInOpenedEditors = !!config.workbench.editor.enablePreview; // No need to delay if preview is disabled
+
+					const activeGroup = this.editorGroupService.activeGroup;
+					if (delayEditorOpeningInOpenedEditors && group === activeGroup && !activeGroup.previewEditor) {
+						delay = 250; // a new editor entry is likely because there is either no group or no preview in group
+					}
+
+					openEditorsView.setStructuralRefreshDelay(delay);
+				}
+
+				try {
+					return await delegate(group, editor, options);
+				} catch (error) {
+					return null; // ignore
+				} finally {
+					if (openEditorsView) {
+						openEditorsView.setStructuralRefreshDelay(0);
+					}
+				}
+			});
+
+			const explorerInstantiator = this.instantiationService.createChild(new ServiceCollection([IEditorService, delegatingEditorService]));
+			return explorerInstantiator.createInstance(ExplorerView, options);
+		}
+		return super.createView(viewDescriptor, options);
+	}
+
+	public getExplorerView(): ExplorerView {
+		return <ExplorerView>this.getView(VIEW_ID);
+	}
+
+	public getOpenEditorsView(): OpenEditorsView {
+		return <OpenEditorsView>this.getView(OpenEditorsView.ID);
+	}
+
+	public setVisible(visible: boolean): void {
+		this.viewletVisibleContextKey.set(visible);
+		super.setVisible(visible);
+	}
+
+	focus(): void {
+		const explorerView = this.getView(VIEW_ID);
+		if (explorerView?.isExpanded()) {
+			explorerView.focus();
+		} else {
+			super.focus();
+		}
+	}
+}
+
+const viewContainerRegistry = Registry.as<IViewContainersRegistry>(Extensions.ViewContainersRegistry);
+
+/**
+ * Explorer viewlet container.
+ */
+export const VIEW_CONTAINER: ViewContainer = viewContainerRegistry.registerViewContainer({
+	id: VIEWLET_ID,
+	name: localize('explore', "Explorer"),
+	ctorDescriptor: new SyncDescriptor(ExplorerViewPaneContainer),
+	storageId: 'workbench.explorer.views.state',
+	icon: Codicon.files.classNames,
+	alwaysUseContainerInfo: true,
+	order: 0
+}, ViewContainerLocation.Sidebar, true);
+
+const viewsRegistry = Registry.as<IViewsRegistry>(Extensions.ViewsRegistry);
+viewsRegistry.registerViewWelcomeContent(EmptyView.ID, {
+	content: localize({ key: 'noWorkspaceHelp', comment: ['Please do not translate the word "commmand", it is part of our internal syntax which must not change'] },
+		"You have not yet added a folder to the workspace.\n[Add Folder](command:{0})", AddRootFolderAction.ID),
+	when: WorkbenchStateContext.isEqualTo('workspace')
+});
+
+const commandId = isMacintosh ? OpenFileFolderAction.ID : OpenFolderAction.ID;
+viewsRegistry.registerViewWelcomeContent(EmptyView.ID, {
+	content: localize({ key: 'remoteNoFolderHelp', comment: ['Please do not translate the word "commmand", it is part of our internal syntax which must not change'] },
+		"Connected to remote.\n[Open Folder](command:{0})", commandId),
+	when: ContextKeyExpr.and(WorkbenchStateContext.notEqualsTo('workspace'), RemoteNameContext.notEqualsTo(''), IsWebContext.toNegated())
+});
+
+viewsRegistry.registerViewWelcomeContent(EmptyView.ID, {
+	content: localize({ key: 'noFolderHelp', comment: ['Please do not translate the word "commmand", it is part of our internal syntax which must not change'] },
+		"You have not yet opened a folder.\n[Open Folder](command:{0})", commandId),
+	when: ContextKeyExpr.or(ContextKeyExpr.and(WorkbenchStateContext.notEqualsTo('workspace'), RemoteNameContext.isEqualTo('')), ContextKeyExpr.and(WorkbenchStateContext.notEqualsTo('workspace'), IsWebContext))
+});

--- a/src/vs/workbench/contrib/scopeTree/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/files.contribution.ts
@@ -1,0 +1,456 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI, UriComponents } from 'vs/base/common/uri';
+import { ShowViewletAction } from 'vs/workbench/browser/viewlet';
+import * as nls from 'vs/nls';
+import { sep } from 'vs/base/common/path';
+import { SyncActionDescriptor, MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationPropertySchema } from 'vs/platform/configuration/common/configurationRegistry';
+import { IWorkbenchActionRegistry, Extensions as ActionExtensions } from 'vs/workbench/common/actions';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
+import { IEditorInputFactory, EditorInput, IFileEditorInput, IEditorInputFactoryRegistry, Extensions as EditorInputExtensions } from 'vs/workbench/common/editor';
+import { AutoSaveConfiguration, HotExitConfiguration, FILES_EXCLUDE_CONFIG, FILES_ASSOCIATIONS_CONFIG } from 'vs/platform/files/common/files';
+import { VIEWLET_ID, SortOrder, FILE_EDITOR_INPUT_ID, IExplorerService } from 'vs/workbench/contrib/files/common/files';
+import { TextFileEditorTracker } from 'vs/workbench/contrib/files/browser/editors/textFileEditorTracker';
+import { TextFileSaveErrorHandler } from 'vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler';
+import { FileEditorInput } from 'vs/workbench/contrib/files/common/editors/fileEditorInput';
+import { BinaryFileEditor } from 'vs/workbench/contrib/files/browser/editors/binaryFileEditor';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { IKeybindings } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { IViewletService } from 'vs/workbench/services/viewlet/browser/viewlet';
+import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
+import * as platform from 'vs/base/common/platform';
+import { ExplorerViewletViewsContribution } from 'vs/workbench/contrib/files/browser/explorerViewlet';
+import { IEditorRegistry, EditorDescriptor, Extensions as EditorExtensions } from 'vs/workbench/browser/editor';
+import { LifecyclePhase } from 'vs/platform/lifecycle/common/lifecycle';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
+import { registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { ExplorerService } from 'vs/workbench/contrib/files/common/explorerService';
+import { SUPPORTED_ENCODINGS } from 'vs/workbench/services/textfile/common/encoding';
+import { Schemas } from 'vs/base/common/network';
+import { WorkspaceWatcher } from 'vs/workbench/contrib/files/common/workspaceWatcher';
+import { editorConfigurationBaseNode } from 'vs/editor/common/config/commonEditorConfig';
+import { DirtyFilesIndicator } from 'vs/workbench/contrib/files/common/dirtyFilesIndicator';
+import { extUri } from 'vs/base/common/resources';
+
+// Viewlet Action
+export class OpenExplorerViewletAction extends ShowViewletAction {
+	static readonly ID = VIEWLET_ID;
+	static readonly LABEL = nls.localize('showExplorerViewlet', "Show Explorer");
+
+	constructor(
+		id: string,
+		label: string,
+		@IViewletService viewletService: IViewletService,
+		@IEditorGroupsService editorGroupService: IEditorGroupsService,
+		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService
+	) {
+		super(id, label, VIEWLET_ID, viewletService, editorGroupService, layoutService);
+	}
+}
+
+class FileUriLabelContribution implements IWorkbenchContribution {
+
+	constructor(@ILabelService labelService: ILabelService) {
+		labelService.registerFormatter({
+			scheme: Schemas.file,
+			formatting: {
+				label: '${authority}${path}',
+				separator: sep,
+				tildify: !platform.isWindows,
+				normalizeDriveLetter: platform.isWindows,
+				authorityPrefix: sep + sep,
+				workspaceSuffix: ''
+			}
+		});
+	}
+}
+
+registerSingleton(IExplorerService, ExplorerService, true);
+
+const openViewletKb: IKeybindings = {
+	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_E
+};
+
+// Register Action to Open Viewlet
+const registry = Registry.as<IWorkbenchActionRegistry>(ActionExtensions.WorkbenchActions);
+registry.registerWorkbenchAction(
+	SyncActionDescriptor.from(OpenExplorerViewletAction, openViewletKb),
+	'View: Show Explorer',
+	nls.localize('view', "View")
+);
+
+// Register file editors
+Registry.as<IEditorRegistry>(EditorExtensions.Editors).registerEditor(
+	EditorDescriptor.create(
+		BinaryFileEditor,
+		BinaryFileEditor.ID,
+		nls.localize('binaryFileEditor', "Binary File Editor")
+	),
+	[
+		new SyncDescriptor<EditorInput>(FileEditorInput)
+	]
+);
+
+// Register default file input factory
+Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactories).registerFileEditorInputFactory({
+	createFileEditorInput: (resource, preferredResource, encoding, mode, instantiationService): IFileEditorInput => {
+		return instantiationService.createInstance(FileEditorInput, resource, preferredResource, encoding, mode);
+	},
+
+	isFileEditorInput: (obj): obj is IFileEditorInput => {
+		return obj instanceof FileEditorInput;
+	}
+});
+
+interface ISerializedFileEditorInput {
+	resourceJSON: UriComponents;
+	preferredResourceJSON?: UriComponents;
+	encoding?: string;
+	modeId?: string;
+}
+
+// Register Editor Input Factory
+class FileEditorInputFactory implements IEditorInputFactory {
+
+	canSerialize(editorInput: EditorInput): boolean {
+		return true;
+	}
+
+	serialize(editorInput: EditorInput): string {
+		const fileEditorInput = <FileEditorInput>editorInput;
+		const resource = fileEditorInput.resource;
+		const preferredResource = fileEditorInput.preferredResource;
+		const serializedFileEditorInput: ISerializedFileEditorInput = {
+			resourceJSON: resource.toJSON(),
+			preferredResourceJSON: extUri.isEqual(resource, preferredResource) ? undefined : preferredResource, // only storing preferredResource if it differs from the resource
+			encoding: fileEditorInput.getEncoding(),
+			modeId: fileEditorInput.getPreferredMode() // only using the preferred user associated mode here if available to not store redundant data
+		};
+
+		return JSON.stringify(serializedFileEditorInput);
+	}
+
+	deserialize(instantiationService: IInstantiationService, serializedEditorInput: string): FileEditorInput {
+		return instantiationService.invokeFunction<FileEditorInput>(accessor => {
+			const serializedFileEditorInput: ISerializedFileEditorInput = JSON.parse(serializedEditorInput);
+			const resource = URI.revive(serializedFileEditorInput.resourceJSON);
+			const preferredResource = URI.revive(serializedFileEditorInput.preferredResourceJSON);
+			const encoding = serializedFileEditorInput.encoding;
+			const mode = serializedFileEditorInput.modeId;
+
+			const fileEditorInput = accessor.get(IEditorService).createEditorInput({ resource, encoding, mode, forceFile: true }) as FileEditorInput;
+			if (preferredResource) {
+				fileEditorInput.setPreferredResource(preferredResource);
+			}
+
+			return fileEditorInput;
+		});
+	}
+}
+
+Registry.as<IEditorInputFactoryRegistry>(EditorInputExtensions.EditorInputFactories).registerEditorInputFactory(FILE_EDITOR_INPUT_ID, FileEditorInputFactory);
+
+// Register Explorer views
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(ExplorerViewletViewsContribution, LifecyclePhase.Starting);
+
+// Register Text File Editor Tracker
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(TextFileEditorTracker, LifecyclePhase.Starting);
+
+// Register Text File Save Error Handler
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(TextFileSaveErrorHandler, LifecyclePhase.Starting);
+
+// Register uri display for file uris
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(FileUriLabelContribution, LifecyclePhase.Starting);
+
+// Register Workspace Watcher
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(WorkspaceWatcher, LifecyclePhase.Restored);
+
+// Register Dirty Files Indicator
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(DirtyFilesIndicator, LifecyclePhase.Starting);
+
+// Configuration
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+
+const hotExitConfiguration: IConfigurationPropertySchema = platform.isNative ?
+	{
+		'type': 'string',
+		'scope': ConfigurationScope.APPLICATION,
+		'enum': [HotExitConfiguration.OFF, HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE],
+		'default': HotExitConfiguration.ON_EXIT,
+		'markdownEnumDescriptions': [
+			nls.localize('hotExit.off', 'Disable hot exit. A prompt will show when attempting to close a window with dirty files.'),
+			nls.localize('hotExit.onExit', 'Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu). All windows without folders opened will be restored upon next launch. A list of workspaces with unsaved files can be accessed via `File > Open Recent > More...`'),
+			nls.localize('hotExit.onExitAndWindowClose', 'Hot exit will be triggered when the last window is closed on Windows/Linux or when the `workbench.action.quit` command is triggered (command palette, keybinding, menu), and also for any window with a folder opened regardless of whether it\'s the last window. All windows without folders opened will be restored upon next launch. A list of workspaces with unsaved files can be accessed via `File > Open Recent > More...`')
+		],
+		'description': nls.localize('hotExit', "Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.", HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE)
+	} : {
+		'type': 'string',
+		'scope': ConfigurationScope.APPLICATION,
+		'enum': [HotExitConfiguration.OFF, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE],
+		'default': HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE,
+		'markdownEnumDescriptions': [
+			nls.localize('hotExit.off', 'Disable hot exit. A prompt will show when attempting to close a window with dirty files.'),
+			nls.localize('hotExit.onExitAndWindowCloseBrowser', 'Hot exit will be triggered when the browser quits or the window or tab is closed.')
+		],
+		'description': nls.localize('hotExit', "Controls whether unsaved files are remembered between sessions, allowing the save prompt when exiting the editor to be skipped.", HotExitConfiguration.ON_EXIT, HotExitConfiguration.ON_EXIT_AND_WINDOW_CLOSE)
+	};
+
+configurationRegistry.registerConfiguration({
+	'id': 'files',
+	'order': 9,
+	'title': nls.localize('filesConfigurationTitle', "Files"),
+	'type': 'object',
+	'properties': {
+		[FILES_EXCLUDE_CONFIG]: {
+			'type': 'object',
+			'markdownDescription': nls.localize('exclude', "Configure glob patterns for excluding files and folders. For example, the file Explorer decides which files and folders to show or hide based on this setting. Refer to the `#search.exclude#` setting to define search specific excludes. Read more about glob patterns [here](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)."),
+			'default': { '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true },
+			'scope': ConfigurationScope.RESOURCE,
+			'additionalProperties': {
+				'anyOf': [
+					{
+						'type': 'boolean',
+						'description': nls.localize('files.exclude.boolean', "The glob pattern to match file paths against. Set to true or false to enable or disable the pattern."),
+					},
+					{
+						'type': 'object',
+						'properties': {
+							'when': {
+								'type': 'string', // expression ({ "**/*.js": { "when": "$(basename).js" } })
+								'pattern': '\\w*\\$\\(basename\\)\\w*',
+								'default': '$(basename).ext',
+								'description': nls.localize('files.exclude.when', "Additional check on the siblings of a matching file. Use $(basename) as variable for the matching file name.")
+							}
+						}
+					}
+				]
+			}
+		},
+		[FILES_ASSOCIATIONS_CONFIG]: {
+			'type': 'object',
+			'markdownDescription': nls.localize('associations', "Configure file associations to languages (e.g. `\"*.extension\": \"html\"`). These have precedence over the default associations of the languages installed."),
+			'additionalProperties': {
+				'type': 'string'
+			}
+		},
+		'files.encoding': {
+			'type': 'string',
+			'enum': Object.keys(SUPPORTED_ENCODINGS),
+			'default': 'utf8',
+			'description': nls.localize('encoding', "The default character set encoding to use when reading and writing files. This setting can also be configured per language."),
+			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE,
+			'enumDescriptions': Object.keys(SUPPORTED_ENCODINGS).map(key => SUPPORTED_ENCODINGS[key].labelLong)
+		},
+		'files.autoGuessEncoding': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('autoGuessEncoding', "When enabled, the editor will attempt to guess the character set encoding when opening files. This setting can also be configured per language."),
+			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
+		},
+		'files.eol': {
+			'type': 'string',
+			'enum': [
+				'\n',
+				'\r\n',
+				'auto'
+			],
+			'enumDescriptions': [
+				nls.localize('eol.LF', "LF"),
+				nls.localize('eol.CRLF', "CRLF"),
+				nls.localize('eol.auto', "Uses operating system specific end of line character.")
+			],
+			'default': 'auto',
+			'description': nls.localize('eol', "The default end of line character."),
+			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
+		},
+		'files.enableTrash': {
+			'type': 'boolean',
+			'default': true,
+			'description': nls.localize('useTrash', "Moves files/folders to the OS trash (recycle bin on Windows) when deleting. Disabling this will delete files/folders permanently.")
+		},
+		'files.trimTrailingWhitespace': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('trimTrailingWhitespace', "When enabled, will trim trailing whitespace when saving a file."),
+			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
+		},
+		'files.insertFinalNewline': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('insertFinalNewline', "When enabled, insert a final new line at the end of the file when saving it."),
+			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
+		},
+		'files.trimFinalNewlines': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('trimFinalNewlines', "When enabled, will trim all new lines after the final new line at the end of the file when saving it."),
+			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
+		},
+		'files.autoSave': {
+			'type': 'string',
+			'enum': [AutoSaveConfiguration.OFF, AutoSaveConfiguration.AFTER_DELAY, AutoSaveConfiguration.ON_FOCUS_CHANGE, AutoSaveConfiguration.ON_WINDOW_CHANGE],
+			'markdownEnumDescriptions': [
+				nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'files.autoSave.off' }, "A dirty editor is never automatically saved."),
+				nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'files.autoSave.afterDelay' }, "A dirty editor is automatically saved after the configured `#files.autoSaveDelay#`."),
+				nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'files.autoSave.onFocusChange' }, "A dirty editor is automatically saved when the editor loses focus."),
+				nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'files.autoSave.onWindowChange' }, "A dirty editor is automatically saved when the window loses focus.")
+			],
+			'default': platform.isWeb ? AutoSaveConfiguration.AFTER_DELAY : AutoSaveConfiguration.OFF,
+			'markdownDescription': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'autoSave' }, "Controls auto save of dirty editors. Read more about autosave [here](https://code.visualstudio.com/docs/editor/codebasics#_save-auto-save).", AutoSaveConfiguration.OFF, AutoSaveConfiguration.AFTER_DELAY, AutoSaveConfiguration.ON_FOCUS_CHANGE, AutoSaveConfiguration.ON_WINDOW_CHANGE, AutoSaveConfiguration.AFTER_DELAY)
+		},
+		'files.autoSaveDelay': {
+			'type': 'number',
+			'default': 1000,
+			'markdownDescription': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'autoSaveDelay' }, "Controls the delay in ms after which a dirty editor is saved automatically. Only applies when `#files.autoSave#` is set to `{0}`.", AutoSaveConfiguration.AFTER_DELAY)
+		},
+		'files.watcherExclude': {
+			'type': 'object',
+			'default': platform.isWindows /* https://github.com/Microsoft/vscode/issues/23954 */ ? { '**/.git/objects/**': true, '**/.git/subtree-cache/**': true, '**/node_modules/*/**': true, '**/.hg/store/**': true } : { '**/.git/objects/**': true, '**/.git/subtree-cache/**': true, '**/node_modules/**': true, '**/.hg/store/**': true },
+			'description': nls.localize('watcherExclude', "Configure glob patterns of file paths to exclude from file watching. Patterns must match on absolute paths (i.e. prefix with ** or the full path to match properly). Changing this setting requires a restart. When you experience Code consuming lots of CPU time on startup, you can exclude large folders to reduce the initial load."),
+			'scope': ConfigurationScope.RESOURCE
+		},
+		'files.hotExit': hotExitConfiguration,
+		'files.defaultLanguage': {
+			'type': 'string',
+			'markdownDescription': nls.localize('defaultLanguage', "The default language mode that is assigned to new files. If configured to `${activeEditorLanguage}`, will use the language mode of the currently active text editor if any.")
+		},
+		'files.maxMemoryForLargeFilesMB': {
+			'type': 'number',
+			'default': 4096,
+			'markdownDescription': nls.localize('maxMemoryForLargeFilesMB', "Controls the memory available to VS Code after restart when trying to open large files. Same effect as specifying `--max-memory=NEWSIZE` on the command line."),
+			included: platform.isNative
+		},
+		'files.restoreUndoStack': {
+			'type': 'boolean',
+			'description': nls.localize('files.restoreUndoStack', "Restore the undo stack when a file is reopened."),
+			'default': true
+		},
+		'files.saveConflictResolution': {
+			'type': 'string',
+			'enum': [
+				'askUser',
+				'overwriteFileOnDisk'
+			],
+			'enumDescriptions': [
+				nls.localize('askUser', "Will refuse to save and ask for resolving the save conflict manually."),
+				nls.localize('overwriteFileOnDisk', "Will resolve the save conflict by overwriting the file on disk with the changes in the editor.")
+			],
+			'description': nls.localize('files.saveConflictResolution', "A save conflict can occur when a file is saved to disk that was changed by another program in the meantime. To prevent data loss, the user is asked to compare the changes in the editor with the version on disk. This setting should only be changed if you frequently encounter save conflict errors and may result in data loss if used without caution."),
+			'default': 'askUser',
+			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
+		},
+		'files.simpleDialog.enable': {
+			'type': 'boolean',
+			'description': nls.localize('files.simpleDialog.enable', "Enables the simple file dialog. The simple file dialog replaces the system file dialog when enabled."),
+			'default': false
+		}
+	}
+});
+
+configurationRegistry.registerConfiguration({
+	...editorConfigurationBaseNode,
+	properties: {
+		'editor.formatOnSave': {
+			'type': 'boolean',
+			'default': false,
+			'description': nls.localize('formatOnSave', "Format a file on save. A formatter must be available, the file must not be saved after delay, and the editor must not be shutting down."),
+			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
+		}
+	}
+});
+
+configurationRegistry.registerConfiguration({
+	'id': 'explorer',
+	'order': 10,
+	'title': nls.localize('explorerConfigurationTitle', "File Explorer"),
+	'type': 'object',
+	'properties': {
+		'explorer.openEditors.visible': {
+			'type': 'number',
+			'description': nls.localize({ key: 'openEditorsVisible', comment: ['Open is an adjective'] }, "Number of editors shown in the Open Editors pane."),
+			'default': 9
+		},
+		'explorer.autoReveal': {
+			'type': ['boolean', 'string'],
+			'enum': [true, false, 'focusNoScroll'],
+			'default': true,
+			'enumDescriptions': [
+				nls.localize('autoReveal.on', 'Files will be revealed and selected.'),
+				nls.localize('autoReveal.off', 'Files will not be revealed and selected.'),
+				nls.localize('autoReveal.focusNoScroll', 'Files will not be scrolled into view, but will still be focused.'),
+			],
+			'description': nls.localize('autoReveal', "Controls whether the explorer should automatically reveal and select files when opening them.")
+		},
+		'explorer.enableDragAndDrop': {
+			'type': 'boolean',
+			'description': nls.localize('enableDragAndDrop', "Controls whether the explorer should allow to move files and folders via drag and drop."),
+			'default': true
+		},
+		'explorer.confirmDragAndDrop': {
+			'type': 'boolean',
+			'description': nls.localize('confirmDragAndDrop', "Controls whether the explorer should ask for confirmation to move files and folders via drag and drop."),
+			'default': true
+		},
+		'explorer.confirmDelete': {
+			'type': 'boolean',
+			'description': nls.localize('confirmDelete', "Controls whether the explorer should ask for confirmation when deleting a file via the trash."),
+			'default': true
+		},
+		'explorer.sortOrder': {
+			'type': 'string',
+			'enum': [SortOrder.Default, SortOrder.Mixed, SortOrder.FilesFirst, SortOrder.Type, SortOrder.Modified],
+			'default': SortOrder.Default,
+			'enumDescriptions': [
+				nls.localize('sortOrder.default', 'Files and folders are sorted by their names, in alphabetical order. Folders are displayed before files.'),
+				nls.localize('sortOrder.mixed', 'Files and folders are sorted by their names, in alphabetical order. Files are interwoven with folders.'),
+				nls.localize('sortOrder.filesFirst', 'Files and folders are sorted by their names, in alphabetical order. Files are displayed before folders.'),
+				nls.localize('sortOrder.type', 'Files and folders are sorted by their extensions, in alphabetical order. Folders are displayed before files.'),
+				nls.localize('sortOrder.modified', 'Files and folders are sorted by last modified date, in descending order. Folders are displayed before files.')
+			],
+			'description': nls.localize('sortOrder', "Controls sorting order of files and folders in the explorer.")
+		},
+		'explorer.decorations.colors': {
+			type: 'boolean',
+			description: nls.localize('explorer.decorations.colors', "Controls whether file decorations should use colors."),
+			default: true
+		},
+		'explorer.decorations.badges': {
+			type: 'boolean',
+			description: nls.localize('explorer.decorations.badges', "Controls whether file decorations should use badges."),
+			default: true
+		},
+		'explorer.incrementalNaming': {
+			enum: ['simple', 'smart'],
+			enumDescriptions: [
+				nls.localize('simple', "Appends the word \"copy\" at the end of the duplicated name potentially followed by a number"),
+				nls.localize('smart', "Adds a number at the end of the duplicated name. If some number is already part of the name, tries to increase that number")
+			],
+			description: nls.localize('explorer.incrementalNaming', "Controls what naming strategy to use when a giving a new name to a duplicated explorer item on paste."),
+			default: 'simple'
+		},
+		'explorer.compactFolders': {
+			'type': 'boolean',
+			'description': nls.localize('compressSingleChildFolders', "Controls whether the explorer should render folders in a compact form. In such a form, single child folders will be compressed in a combined tree element. Useful for Java package structures, for example."),
+			'default': true
+		},
+	}
+});
+
+// View menu
+MenuRegistry.appendMenuItem(MenuId.MenubarViewMenu, {
+	group: '3_views',
+	command: {
+		id: VIEWLET_ID,
+		title: nls.localize({ key: 'miViewExplorer', comment: ['&& denotes a mnemonic'] }, "&&Explorer")
+	},
+	order: 1
+});

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -1,0 +1,396 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Event } from 'vs/base/common/event';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { IExplorerService, IFilesConfiguration, SortOrder, IExplorerView } from 'vs/workbench/contrib/files/common/files';
+import { ExplorerItem, ExplorerModel } from 'vs/workbench/contrib/files/common/explorerModel';
+import { URI } from 'vs/base/common/uri';
+import { FileOperationEvent, FileOperation, IFileService, FileChangesEvent, FILES_EXCLUDE_CONFIG, FileChangeType, IResolveFileOptions } from 'vs/platform/files/common/files';
+import { dirname } from 'vs/base/common/resources';
+import { memoize } from 'vs/base/common/decorators';
+import { ResourceGlobMatcher } from 'vs/workbench/common/resources';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
+import { IExpression } from 'vs/base/common/glob';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IEditableData } from 'vs/workbench/common/views';
+
+function getFileEventsExcludes(configurationService: IConfigurationService, root?: URI): IExpression {
+	const scope = root ? { resource: root } : undefined;
+	const configuration = scope ? configurationService.getValue<IFilesConfiguration>(scope) : configurationService.getValue<IFilesConfiguration>();
+
+	return configuration?.files?.exclude || Object.create(null);
+}
+
+export class ExplorerService implements IExplorerService {
+	declare readonly _serviceBrand: undefined;
+
+	private static readonly EXPLORER_FILE_CHANGES_REACT_DELAY = 500; // delay in ms to react to file changes to give our internal events a chance to react first
+
+	private readonly disposables = new DisposableStore();
+	private editable: { stat: ExplorerItem, data: IEditableData } | undefined;
+	private _sortOrder: SortOrder;
+	private cutItems: ExplorerItem[] | undefined;
+	private view: IExplorerView | undefined;
+	private model: ExplorerModel;
+
+	constructor(
+		@IFileService private fileService: IFileService,
+		@IInstantiationService private instantiationService: IInstantiationService,
+		@IConfigurationService private configurationService: IConfigurationService,
+		@IWorkspaceContextService private contextService: IWorkspaceContextService,
+		@IClipboardService private clipboardService: IClipboardService,
+		@IEditorService private editorService: IEditorService,
+	) {
+		this._sortOrder = this.configurationService.getValue('explorer.sortOrder');
+
+		this.model = new ExplorerModel(this.contextService, this.fileService);
+		this.disposables.add(this.model);
+		this.disposables.add(this.fileService.onDidRunOperation(e => this.onDidRunOperation(e)));
+		this.disposables.add(this.fileService.onDidFilesChange(e => this.onDidFilesChange(e)));
+		this.disposables.add(this.configurationService.onDidChangeConfiguration(e => this.onConfigurationUpdated(this.configurationService.getValue<IFilesConfiguration>())));
+		this.disposables.add(Event.any<{ scheme: string }>(this.fileService.onDidChangeFileSystemProviderRegistrations, this.fileService.onDidChangeFileSystemProviderCapabilities)(async e => {
+			let affected = false;
+			this.model.roots.forEach(r => {
+				if (r.resource.scheme === e.scheme) {
+					affected = true;
+					r.forgetChildren();
+				}
+			});
+			if (affected) {
+				if (this.view) {
+					await this.view.refresh(true);
+				}
+			}
+		}));
+		this.disposables.add(this.model.onDidChangeRoots(() => {
+			if (this.view) {
+				this.view.setTreeInput();
+			}
+		}));
+	}
+
+	get roots(): ExplorerItem[] {
+		return this.model.roots;
+	}
+
+	get sortOrder(): SortOrder {
+		return this._sortOrder;
+	}
+
+	registerView(contextProvider: IExplorerView): void {
+		this.view = contextProvider;
+	}
+
+	getContext(respectMultiSelection: boolean): ExplorerItem[] {
+		if (!this.view) {
+			return [];
+		}
+		return this.view.getContext(respectMultiSelection);
+	}
+
+	// Memoized locals
+	@memoize private get fileEventsFilter(): ResourceGlobMatcher {
+		const fileEventsFilter = this.instantiationService.createInstance(
+			ResourceGlobMatcher,
+			(root?: URI) => getFileEventsExcludes(this.configurationService, root),
+			(event: IConfigurationChangeEvent) => event.affectsConfiguration(FILES_EXCLUDE_CONFIG)
+		);
+		this.disposables.add(fileEventsFilter);
+
+		return fileEventsFilter;
+	}
+
+	// IExplorerService methods
+
+	findClosest(resource: URI): ExplorerItem | null {
+		return this.model.findClosest(resource);
+	}
+
+	async setEditable(stat: ExplorerItem, data: IEditableData | null): Promise<void> {
+		if (!this.view) {
+			return;
+		}
+
+		if (!data) {
+			this.editable = undefined;
+		} else {
+			this.editable = { stat, data };
+		}
+		const isEditing = this.isEditable(stat);
+		await this.view.setEditable(stat, isEditing);
+	}
+
+	async setToCopy(items: ExplorerItem[], cut: boolean): Promise<void> {
+		const previouslyCutItems = this.cutItems;
+		this.cutItems = cut ? items : undefined;
+		await this.clipboardService.writeResources(items.map(s => s.resource));
+
+		this.view?.itemsCopied(items, cut, previouslyCutItems);
+	}
+
+	isCut(item: ExplorerItem): boolean {
+		return !!this.cutItems && this.cutItems.indexOf(item) >= 0;
+	}
+
+	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {
+		return this.editable;
+	}
+
+	getEditableData(stat: ExplorerItem): IEditableData | undefined {
+		return this.editable && this.editable.stat === stat ? this.editable.data : undefined;
+	}
+
+	isEditable(stat: ExplorerItem | undefined): boolean {
+		return !!this.editable && (this.editable.stat === stat || !stat);
+	}
+
+	async select(resource: URI, reveal?: boolean | string): Promise<void> {
+		if (!this.view) {
+			return;
+		}
+
+		const fileStat = this.findClosest(resource);
+		if (fileStat) {
+			await this.view.selectResource(fileStat.resource, reveal);
+			return Promise.resolve(undefined);
+		}
+
+		// Stat needs to be resolved first and then revealed
+		const options: IResolveFileOptions = { resolveTo: [resource], resolveMetadata: this.sortOrder === SortOrder.Modified };
+		const workspaceFolder = this.contextService.getWorkspaceFolder(resource);
+		if (workspaceFolder === null) {
+			return Promise.resolve(undefined);
+		}
+		const rootUri = workspaceFolder.uri;
+
+		const root = this.roots.find(r => r.resource.toString() === rootUri.toString())!;
+
+		try {
+			const stat = await this.fileService.resolve(rootUri, options);
+
+			// Convert to model
+			const modelStat = ExplorerItem.create(this.fileService, stat, undefined, options.resolveTo);
+			// Update Input with disk Stat
+			ExplorerItem.mergeLocalWithDisk(modelStat, root);
+			const item = root.find(resource);
+			await this.view.refresh(true, root);
+
+			// Select and Reveal
+			await this.view.selectResource(item ? item.resource : undefined, reveal);
+		} catch (error) {
+			root.isError = true;
+			await this.view.refresh(false, root);
+		}
+	}
+
+	async refresh(reveal = true): Promise<void> {
+		this.model.roots.forEach(r => r.forgetChildren());
+		if (this.view) {
+			await this.view.refresh(true);
+			const resource = this.editorService.activeEditor ? this.editorService.activeEditor.resource : undefined;
+			const autoReveal = this.configurationService.getValue<IFilesConfiguration>().explorer.autoReveal;
+
+			if (reveal && resource && autoReveal) {
+				// We did a top level refresh, reveal the active file #67118
+				this.select(resource, autoReveal);
+			}
+		}
+	}
+
+	// File events
+
+	private async onDidRunOperation(e: FileOperationEvent): Promise<void> {
+		// Add
+		if (e.isOperation(FileOperation.CREATE) || e.isOperation(FileOperation.COPY)) {
+			const addedElement = e.target;
+			const parentResource = dirname(addedElement.resource)!;
+			const parents = this.model.findAll(parentResource);
+
+			if (parents.length) {
+
+				// Add the new file to its parent (Model)
+				parents.forEach(async p => {
+					// We have to check if the parent is resolved #29177
+					const resolveMetadata = this.sortOrder === `modified`;
+					if (!p.isDirectoryResolved) {
+						const stat = await this.fileService.resolve(p.resource, { resolveMetadata });
+						if (stat) {
+							const modelStat = ExplorerItem.create(this.fileService, stat, p.parent);
+							ExplorerItem.mergeLocalWithDisk(modelStat, p);
+						}
+					}
+
+					const childElement = ExplorerItem.create(this.fileService, addedElement, p.parent);
+					// Make sure to remove any previous version of the file if any
+					p.removeChild(childElement);
+					p.addChild(childElement);
+					// Refresh the Parent (View)
+					await this.view?.refresh(false, p);
+				});
+			}
+		}
+
+		// Move (including Rename)
+		else if (e.isOperation(FileOperation.MOVE)) {
+			const oldResource = e.resource;
+			const newElement = e.target;
+			const oldParentResource = dirname(oldResource);
+			const newParentResource = dirname(newElement.resource);
+
+			// Handle Rename
+			if (oldParentResource.toString() === newParentResource.toString()) {
+				const modelElements = this.model.findAll(oldResource);
+				modelElements.forEach(async modelElement => {
+					// Rename File (Model)
+					modelElement.rename(newElement);
+					await this.view?.refresh(false, modelElement.parent);
+				});
+			}
+
+			// Handle Move
+			else {
+				const newParents = this.model.findAll(newParentResource);
+				const modelElements = this.model.findAll(oldResource);
+
+				if (newParents.length && modelElements.length) {
+					// Move in Model
+					modelElements.forEach(async (modelElement, index) => {
+						const oldParent = modelElement.parent;
+						modelElement.move(newParents[index]);
+						await this.view?.refresh(false, oldParent);
+						await this.view?.refresh(false, newParents[index]);
+					});
+				}
+			}
+		}
+
+		// Delete
+		else if (e.isOperation(FileOperation.DELETE)) {
+			const modelElements = this.model.findAll(e.resource);
+			modelElements.forEach(async element => {
+				if (element.parent) {
+					const parent = element.parent;
+					// Remove Element from Parent (Model)
+					parent.removeChild(element);
+					// Refresh Parent (View)
+					await this.view?.refresh(false, parent);
+				}
+			});
+		}
+	}
+
+	private onDidFilesChange(e: FileChangesEvent): void {
+		// Check if an explorer refresh is necessary (delayed to give internal events a chance to react first)
+		// Note: there is no guarantee when the internal events are fired vs real ones. Code has to deal with the fact that one might
+		// be fired first over the other or not at all.
+		setTimeout(async () => {
+			// Filter to the ones we care
+			const shouldRefresh = () => {
+				e = this.filterToViewRelevantEvents(e);
+				// Handle added files/folders
+				const added = e.getAdded();
+				if (added.length) {
+
+					// Check added: Refresh if added file/folder is not part of resolved root and parent is part of it
+					const ignoredPaths: Set<string> = new Set();
+					for (let i = 0; i < added.length; i++) {
+						const change = added[i];
+
+						// Find parent
+						const parent = dirname(change.resource);
+
+						// Continue if parent was already determined as to be ignored
+						if (ignoredPaths.has(parent.toString())) {
+							continue;
+						}
+
+						// Compute if parent is visible and added file not yet part of it
+						const parentStat = this.model.findClosest(parent);
+						if (parentStat && parentStat.isDirectoryResolved && !this.model.findClosest(change.resource)) {
+							return true;
+						}
+
+						// Keep track of path that can be ignored for faster lookup
+						if (!parentStat || !parentStat.isDirectoryResolved) {
+							ignoredPaths.add(parent.toString());
+						}
+					}
+				}
+
+				// Handle deleted files/folders
+				const deleted = e.getDeleted();
+				if (deleted.length) {
+
+					// Check deleted: Refresh if deleted file/folder part of resolved root
+					for (let j = 0; j < deleted.length; j++) {
+						const del = deleted[j];
+						const item = this.model.findClosest(del.resource);
+						if (item && item.parent) {
+							return true;
+						}
+					}
+				}
+
+				// Handle updated files/folders if we sort by modified
+				if (this._sortOrder === SortOrder.Modified) {
+					const updated = e.getUpdated();
+
+					// Check updated: Refresh if updated file/folder part of resolved root
+					for (let j = 0; j < updated.length; j++) {
+						const upd = updated[j];
+						const item = this.model.findClosest(upd.resource);
+
+						if (item && item.parent) {
+							return true;
+						}
+					}
+				}
+
+				return false;
+			};
+
+			if (shouldRefresh()) {
+				await this.refresh(false);
+			}
+		}, ExplorerService.EXPLORER_FILE_CHANGES_REACT_DELAY);
+	}
+
+	private filterToViewRelevantEvents(e: FileChangesEvent): FileChangesEvent {
+		return e.filter(change => {
+			if (change.type === FileChangeType.UPDATED && this._sortOrder !== SortOrder.Modified) {
+				return false; // we only are about updated if we sort by modified time
+			}
+
+			if (!this.contextService.isInsideWorkspace(change.resource)) {
+				return false; // exclude changes for resources outside of workspace
+			}
+
+			if (this.fileEventsFilter.matches(change.resource)) {
+				return false; // excluded via files.exclude setting
+			}
+
+			return true;
+		});
+	}
+
+	private async onConfigurationUpdated(configuration: IFilesConfiguration, event?: IConfigurationChangeEvent): Promise<void> {
+		const configSortOrder = configuration?.explorer?.sortOrder || 'default';
+		if (this._sortOrder !== configSortOrder) {
+			const shouldRefresh = this._sortOrder !== undefined;
+			this._sortOrder = configSortOrder;
+			if (shouldRefresh) {
+				await this.refresh();
+			}
+		}
+	}
+
+	dispose(): void {
+		this.disposables.dispose();
+	}
+}


### PR DESCRIPTION
Files copied (no changes):
1. browser/explorerView.ts  => main file where functionality will be implemented
2. browser/explorerViewer.ts => new explorer viewer, where front end will be added (icons, breadcrumbs, buttons)
3, browser/explorerViewlet.ts => will be registered in workbench.common.view with the new ExplorerView.
4. browser/files.contribution.ts => will register the new explorerViewlet.
5. common/explorerService.ts => will implement IExplorerService and extend it with setRoot(resource) method

Also modified resources.json because component had to be registered there before commiting.