### PR TITLE
Added setRoot(resource) method to interfaces and explorerService class

### DIFF
--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -25,7 +25,7 @@ export class ExplorerModel implements IDisposable {
 
 	constructor(
 		private readonly contextService: IWorkspaceContextService,
-		fileService: IFileService
+		private readonly fileService: IFileService
 	) {
 		const setRoots = () => this._roots = this.contextService.getWorkspace().folders
 			.map(folder => new ExplorerItem(folder.uri, fileService, undefined, true, false, folder.name));
@@ -43,6 +43,18 @@ export class ExplorerModel implements IDisposable {
 
 	get onDidChangeRoots(): Event<void> {
 		return this._onDidChangeRoots.event;
+	}
+
+	async setRoot(resource: URI): Promise<void> {
+		const root = new ExplorerItem(resource, this.fileService, undefined);
+
+		const children = await root.fetchChildren(SortOrder.Default);
+
+		children.forEach(child => {
+			root.addChild(child);
+		});
+
+		this._roots = [root];
 	}
 
 	/**

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -66,7 +66,6 @@ export interface IExplorerView {
 	setTreeInput(): Promise<void>;
 	itemsCopied(tats: ExplorerItem[], cut: boolean, previousCut: ExplorerItem[] | undefined): void;
 	setEditable(stat: ExplorerItem, isEditing: boolean): Promise<void>;
-	setRoot(resource: URI): void;
 }
 
 export const IExplorerService = createDecorator<IExplorerService>('explorerService');

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -48,7 +48,7 @@ export interface IExplorerService {
 	refresh(): Promise<void>;
 	setToCopy(stats: ExplorerItem[], cut: boolean): Promise<void>;
 	isCut(stat: ExplorerItem): boolean;
-	setRoot(resource: URI): Promise<void>;
+	setRoot(resource: URI): void;
 
 	/**
 	 * Selects and reveal the file element provided by the given resource if its found in the explorer.
@@ -66,7 +66,7 @@ export interface IExplorerView {
 	setTreeInput(): Promise<void>;
 	itemsCopied(tats: ExplorerItem[], cut: boolean, previousCut: ExplorerItem[] | undefined): void;
 	setEditable(stat: ExplorerItem, isEditing: boolean): Promise<void>;
-	setRoot(resource: URI): Promise<void>;
+	setRoot(resource: URI): void;
 }
 
 export const IExplorerService = createDecorator<IExplorerService>('explorerService');

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -48,6 +48,7 @@ export interface IExplorerService {
 	refresh(): Promise<void>;
 	setToCopy(stats: ExplorerItem[], cut: boolean): Promise<void>;
 	isCut(stat: ExplorerItem): boolean;
+	setRoot(resource: URI): Promise<void>;
 
 	/**
 	 * Selects and reveal the file element provided by the given resource if its found in the explorer.
@@ -65,6 +66,7 @@ export interface IExplorerView {
 	setTreeInput(): Promise<void>;
 	itemsCopied(tats: ExplorerItem[], cut: boolean, previousCut: ExplorerItem[] | undefined): void;
 	setEditable(stat: ExplorerItem, isEditing: boolean): Promise<void>;
+	setRoot(resource: URI): Promise<void>;
 }
 
 export const IExplorerService = createDecorator<IExplorerService>('explorerService');

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -659,7 +659,26 @@ export class ExplorerView extends ViewPane {
 		}
 	}
 
-	public async setRoot(resource: URI): Promise<void> {
+	public setRoot(resource: URI): void {
+		this.explorerService.select(resource, true).then(() => {
+			const newRoot: ExplorerItem | null = this.explorerService.findClosest(resource);
+
+			if (newRoot === null) {
+				throw new Error('Resource not set or could not find resource');
+			}
+
+			if (this.tree.hasNode(newRoot)) {
+				this.tree.expand(newRoot).then((fulfilled: boolean) => {
+					if (!fulfilled) {
+						throw new Error('Could not expand the new root');
+					}
+
+					this.tree.setInput(newRoot as ExplorerItem).then(() => {
+						// Will need to render the breadcrumb and expand ancestors
+					});
+				});
+			}
+		});
 	}
 
 	private getActiveFile(): URI | undefined {

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -659,28 +659,6 @@ export class ExplorerView extends ViewPane {
 		}
 	}
 
-	public setRoot(resource: URI): void {
-		this.explorerService.select(resource, true).then(() => {
-			const newRoot: ExplorerItem | null = this.explorerService.findClosest(resource);
-
-			if (newRoot === null) {
-				throw new Error('Resource not set or could not find resource');
-			}
-
-			if (this.tree.hasNode(newRoot)) {
-				this.tree.expand(newRoot).then((fulfilled: boolean) => {
-					if (!fulfilled) {
-						throw new Error('Could not expand the new root');
-					}
-
-					this.tree.setInput(newRoot as ExplorerItem).then(() => {
-						// Will need to render the breadcrumb and expand ancestors
-					});
-				});
-			}
-		});
-	}
-
 	private getActiveFile(): URI | undefined {
 		const input = this.editorService.activeEditor;
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -659,6 +659,9 @@ export class ExplorerView extends ViewPane {
 		}
 	}
 
+	public async setRoot(resource: URI): Promise<void> {
+	}
+
 	private getActiveFile(): URI | undefined {
 		const input = this.editorService.activeEditor;
 

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -138,8 +138,10 @@ export class ExplorerService implements IExplorerService {
 		return !!this.cutItems && this.cutItems.indexOf(item) >= 0;
 	}
 
-	public setRoot(resource: URI): void {
-		this.view?.setRoot(resource);
+	setRoot(resource: URI): void {
+		this.model.setRoot(resource).then(async () => {
+			await this.view?.setTreeInput();
+		});
 	}
 
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -138,8 +138,8 @@ export class ExplorerService implements IExplorerService {
 		return !!this.cutItems && this.cutItems.indexOf(item) >= 0;
 	}
 
-	public async setRoot(resource: URI): Promise<void> {
-		await this.view?.setRoot(resource);
+	public setRoot(resource: URI): void {
+		this.view?.setRoot(resource);
 	}
 
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -138,6 +138,10 @@ export class ExplorerService implements IExplorerService {
 		return !!this.cutItems && this.cutItems.indexOf(item) >= 0;
 	}
 
+	public async setRoot(resource: URI): Promise<void> {
+		await this.view?.setRoot(resource);
+	}
+
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {
 		return this.editable;
 	}


### PR DESCRIPTION
Added setRoot(resource) method to IExplorerService and IExplorerView interfaces.

Also added it to explorerService (because it implements IExplorerService) and ExplorerView (because it is registered as a view (type IExplorerView) by the explorerService).

No implementation provided yet.