### PR TITLE
Add focus icon and display them on hover.

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -281,6 +281,22 @@ export class ExplorerView extends ViewPane {
 				this.selectActiveFile(false, true);
 			}
 		}));
+
+		this.tree.onMouseOver(e => {
+			const icon = document.getElementById('iconContainer_' + e.element?.resource.toString());
+
+			if (icon !== null) {
+				icon.style.visibility = 'visible';
+			}
+		});
+
+		this.tree.onMouseOut(e => {
+			const icon = document.getElementById('iconContainer_' + e.element?.resource.toString());
+
+			if (icon !== null) {
+				icon.style.visibility = 'hidden';
+			}
+		});
 	}
 
 	getActions(): IAction[] {


### PR DESCRIPTION
explorerViewer.ts
   Added focus icon to each directory. Each focus icon is encapsulated in a RenderFocusIcon object, which implements IDisposables, so that icons are disposed when the stat is rendered again.

explorerView.ts
   Initially, focusIcons are hidden. Visibility changes when user hovers over an item in the file tree. 