### PR TITLE
Hide parent button when a top root is reached

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -236,15 +236,9 @@ export class ExplorerView extends ViewPane {
 	}
 
 	private isWorkspaceRoot(root: URI): boolean {
-		let isRoot = false;
+		const workspaceFolder = this.contextService.getWorkspace().folders.find(folder => folder.uri.toString() === root.toString());
 
-		this.contextService.getWorkspace().folders.forEach(folder => {
-			if (folder.uri.toString() === root.toString()) {
-				isRoot = true;
-			}
-		});
-
-		return isRoot;
+		return workspaceFolder !== undefined;
 	}
 
 	protected renderHeader(container: HTMLElement): void {
@@ -676,8 +670,7 @@ export class ExplorerView extends ViewPane {
 		const promise = this.tree.setInput(input, viewState).then(() => {
 			if (!this.isWorkspaceRoot((input as ExplorerItem).resource)) {
 				this.parentButton.style.visibility = 'visible';
-			}
-			else {
+			} else {
 				this.parentButton.style.visibility = 'hidden';
 			}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -226,12 +226,25 @@ export class ExplorerView extends ViewPane {
 	private renderParentButton() {
 		this.parentButton.style.verticalAlign = 'middle';
 		this.parentButton.style.paddingLeft = '20px';
+		this.parentButton.style.visibility = 'hidden';
 		this.parentButton.onclick = () => {
 			const root = this.tree.getInput() as ExplorerItem;
 			const parentResource = dirname(root.resource);
 
 			this.explorerService.setRoot(parentResource);
 		};
+	}
+
+	private isWorkspaceRoot(root: URI): boolean {
+		let isRoot = false;
+
+		this.contextService.getWorkspace().folders.forEach(folder => {
+			if (folder.uri.toString() === root.toString()) {
+				isRoot = true;
+			}
+		});
+
+		return isRoot;
 	}
 
 	protected renderHeader(container: HTMLElement): void {
@@ -661,6 +674,13 @@ export class ExplorerView extends ViewPane {
 
 		const previousInput = this.tree.getInput();
 		const promise = this.tree.setInput(input, viewState).then(() => {
+			if (!this.isWorkspaceRoot((input as ExplorerItem).resource)) {
+				this.parentButton.style.visibility = 'visible';
+			}
+			else {
+				this.parentButton.style.visibility = 'hidden';
+			}
+
 			if (Array.isArray(input)) {
 				if (!viewState || previousInput instanceof ExplorerItem) {
 					// There is no view state for this workspace, expand all roots. Or we transitioned from a folder workspace.


### PR DESCRIPTION
Initially, the parent button is hidden because you cannot further navigate up the tree.

Visibility of the button is checked whenever the root is changed.