### PR TITLE
Added breadcrumb to the file tree, next to the parent button.

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/media/treeNavigation.css
+++ b/src/vs/workbench/contrib/scopeTree/browser/media/treeNavigation.css
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.breadcrumb-file-tree {
+	list-style: none;
+	background-color: #eee;
+	white-space: nowrap;
+	position: relative;
+	left: -20px;
+}
+
+.breadcrumb-element {
+	display: inline;
+}
+
+.breadcrumb-element-emphasized {
+	display: inline;
+	color: #01447e;
+	text-decoration: underline;
+}
+
+.parent-button {
+	vertical-align: middle;
+	visibility: hidden;
+	padding-right: 5px;
+}


### PR DESCRIPTION
The breadcrumb is a simple unsorted list. Each list item has 3 listeners:
* onclick => sets the root of the tree to the directory indicated by the element.
* onMouseOver => underlines the name of the directory and highlights it, to indicate that the item is clickable.
* onMouseOut => removes the previous style elements from onMouseOver.

parentButton is added as the first child of the breadcrumb in order to make the 2 display inline without changing the styling of the whole div (because this would also affect the file tree).