### PR TITLE
Preserve expanded state when navigating up the tree

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -701,7 +701,15 @@ export class ExplorerView extends ViewPane {
 		}
 
 		const previousInput = this.tree.getInput();
-		const promise = this.tree.setInput(input, viewState).then(() => {
+
+		// If the parent button was pressed, add the previous root to viewState.expanded so that its expanded children are not collapsed.
+		if (previousInput && input instanceof ExplorerItem && previousInput instanceof ExplorerItem) {
+			if (input.find(previousInput.resource)) {
+				viewState?.expanded?.push(previousInput.resource.toString());
+			}
+		}
+
+		const promise = this.tree.setInput(input, viewState).then(async () => {
 			if (!this.isWorkspaceRoot((input as ExplorerItem).resource)) {
 				this.parentButton.style.visibility = 'visible';
 			} else {


### PR DESCRIPTION
When the parent button is pressed, add the previous root to viewState.expanded (which stores the URI of expanded directories in the tree). This will cause the previous root to be expanded, along with all of its children that were expanded before the root was changed.