### PR TITLE
Changed setRoot() in explorerService.ts to be thread safe.

### DIFF
--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -48,7 +48,7 @@ export interface IExplorerService {
 	refresh(): Promise<void>;
 	setToCopy(stats: ExplorerItem[], cut: boolean): Promise<void>;
 	isCut(stat: ExplorerItem): boolean;
-	setRoot(resource: URI): void;
+	setRoot(resource: URI): Promise<void>;
 
 	/**
 	 * Selects and reveal the file element provided by the given resource if its found in the explorer.


### PR DESCRIPTION
Changed setRoot() in explorerService.ts to be thread safe. The return type of setRoot() is now Promise<void>, and this can be used to trigger certain actions in the .then() block (e.g. when the active editor changes, after .setRoot() is executed, the file can be selected).