### PR TITLE
Handle root being deleted by setting the root to the parent directory.

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -972,20 +972,7 @@ export const deleteFileHandler = async (accessor: ServicesAccessor) => {
 	const stats = explorerService.getContext(true).filter(s => !s.isRoot);
 
 	if (stats.length) {
-		const lastItemDeleted = stats[stats.length - 1];
-		const currentRoot = explorerService.roots[0];
-
-		deleteFiles(accessor.get(IWorkingCopyFileService), accessor.get(IDialogService), accessor.get(IConfigurationService), stats, false).then(() => {
-			// If the user deletes the focused directory, focus on the immediate parent directory
-			if (stats.includes(currentRoot) && !explorerService.findClosest(currentRoot.resource)) {
-				explorerService.setRoot(resources.dirname(currentRoot.resource));
-			}
-
-			// Select the parent resource so that the user can keep deleting files using keyboard
-			if (lastItemDeleted.parent && !explorerService.findClosest(lastItemDeleted.resource)) {
-				explorerService.select(lastItemDeleted.parent.resource);
-			}
-		});
+		await deleteFiles(accessor.get(IWorkingCopyFileService), accessor.get(IDialogService), accessor.get(IConfigurationService), stats, false);
 	}
 };
 

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -972,7 +972,20 @@ export const deleteFileHandler = async (accessor: ServicesAccessor) => {
 	const stats = explorerService.getContext(true).filter(s => !s.isRoot);
 
 	if (stats.length) {
-		await deleteFiles(accessor.get(IWorkingCopyFileService), accessor.get(IDialogService), accessor.get(IConfigurationService), stats, false);
+		const lastItemDeleted = stats[stats.length - 1];
+		const currentRoot = explorerService.roots[0];
+
+		deleteFiles(accessor.get(IWorkingCopyFileService), accessor.get(IDialogService), accessor.get(IConfigurationService), stats, false).then(() => {
+			// If the user deletes the focused directory, focus on the immediate parent directory
+			if (stats.includes(currentRoot) && !explorerService.findClosest(currentRoot.resource)) {
+				explorerService.setRoot(resources.dirname(currentRoot.resource));
+			}
+
+			// Select the parent resource so that the user can keep deleting files using keyboard
+			if (lastItemDeleted.parent && !explorerService.findClosest(lastItemDeleted.resource)) {
+				explorerService.select(lastItemDeleted.parent.resource);
+			}
+		});
 	}
 };
 

--- a/src/vs/workbench/contrib/files/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/files/common/explorerModel.ts
@@ -45,10 +45,10 @@ export class ExplorerModel implements IDisposable {
 		return this._onDidChangeRoots.event;
 	}
 
-	async setRoot(resource: URI): Promise<void> {
+	async setRoot(resource: URI, sortOrder: SortOrder): Promise<void> {
 		const root = new ExplorerItem(resource, this.fileService, undefined);
 
-		const children = await root.fetchChildren(SortOrder.Default);
+		const children = await root.fetchChildren(sortOrder);
 
 		children.forEach(child => {
 			root.addChild(child);

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -66,6 +66,7 @@ export interface IExplorerView {
 	setTreeInput(): Promise<void>;
 	itemsCopied(tats: ExplorerItem[], cut: boolean, previousCut: ExplorerItem[] | undefined): void;
 	setEditable(stat: ExplorerItem, isEditing: boolean): Promise<void>;
+	findAdjacentSibling(stat: ExplorerItem): URI | undefined;
 }
 
 export const IExplorerService = createDecorator<IExplorerService>('explorerService');

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -673,6 +673,27 @@ export class ExplorerView extends ViewPane {
 		return DOM.getLargestChildWidth(parentNode, childNodes);
 	}
 
+	findAdjacentSibling(deleted: ExplorerItem): URI | undefined {
+		const orderedChildren: ExplorerItem[] = [];
+		const parent = deleted.parent;
+
+		this.tree.getNode(parent).children.forEach(e => {
+			orderedChildren.push(e.element as ExplorerItem);
+		});
+
+		for (let i = 0; i < orderedChildren.length; i++) {
+			if (orderedChildren[i].resource.toString() === deleted.resource.toString()) {
+				if (i > 0) {
+					return orderedChildren[i - 1].resource;
+				} else if (orderedChildren.length > 1) {
+					return orderedChildren[1].resource;
+				}
+			}
+		}
+
+		return parent ? parent.resource : undefined;
+	}
+
 	async setTreeInput(): Promise<void> {
 		if (!this.isBodyVisible()) {
 			this.shouldRefresh = true;

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -326,7 +326,7 @@ export class ExplorerView extends ViewPane {
 
 		// When the explorer viewer is loaded, listen to changes to the editor input
 		this._register(this.editorService.onDidActiveEditorChange(() => {
-			this.selectActiveFile(true);
+			this.selectActiveFile();
 		}));
 
 		// Also handle configuration updates

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -674,19 +674,16 @@ export class ExplorerView extends ViewPane {
 	}
 
 	findAdjacentSibling(deleted: ExplorerItem): URI | undefined {
-		const orderedChildren: ExplorerItem[] = [];
 		const parent = deleted.parent;
+		const children = this.tree.getNode(parent).children;
 
-		this.tree.getNode(parent).children.forEach(e => {
-			orderedChildren.push(e.element as ExplorerItem);
-		});
-
-		for (let i = 0; i < orderedChildren.length; i++) {
-			if (orderedChildren[i].resource.toString() === deleted.resource.toString()) {
+		for (let i = 0; i < children.length; i++) {
+			const element = children[i].element as ExplorerItem;
+			if (element.resource.toString() === deleted.resource.toString()) {
 				if (i > 0) {
-					return orderedChildren[i - 1].resource;
-				} else if (orderedChildren.length > 1) {
-					return orderedChildren[1].resource;
+					return (children[i - 1].element as ExplorerItem).resource;
+				} else if (children.length > 1) {
+					return (children[1].element as ExplorerItem).resource;
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -139,7 +139,7 @@ export class ExplorerService implements IExplorerService {
 	}
 
 	setRoot(resource: URI): void {
-		this.model.setRoot(resource).then(async () => {
+		this.model.setRoot(resource, this.sortOrder).then(async () => {
 			await this.view?.setTreeInput();
 		});
 	}
@@ -282,10 +282,15 @@ export class ExplorerService implements IExplorerService {
 			modelElements.forEach(async element => {
 				if (element.parent) {
 					const parent = element.parent;
+					const nextSelection = this.view?.findAdjacentSibling(element);
+
 					// Remove Element from Parent (Model)
 					parent.removeChild(element);
 					// Refresh Parent (View)
-					await this.view?.refresh(false, parent);
+					this.view?.refresh(false, parent).then(() => this.view?.selectResource(nextSelection));
+				} else {
+					const parentResource = dirname(element.resource);
+					this.setRoot(parentResource);
 				}
 			});
 		}

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -287,7 +287,9 @@ export class ExplorerService implements IExplorerService {
 					// Remove Element from Parent (Model)
 					parent.removeChild(element);
 					// Refresh Parent (View)
-					this.view?.refresh(false, parent).then(() => this.view?.selectResource(nextSelection));
+					this.view?.refresh(false, parent).then(() => {
+						this.view?.selectResource(nextSelection);
+					});
 				} else {
 					const parentResource = dirname(element.resource);
 					this.setRoot(parentResource);


### PR DESCRIPTION
If the root is deleted, set its parent as the new root.

When a file is deleted, select its parent in the file tree so that keyboard navigation in the file tree remains active.