### PR TITLE
Prevent directory from expanding / collapsing when bookmark icon is clicked

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -924,6 +924,10 @@ function asTreeMouseEvent<T>(event: IListMouseEvent<ITreeNode<T, any>>): ITreeMo
 		target = TreeMouseEventTarget.Twistie;
 	} else if (hasParentWithClass(event.browserEvent.target as HTMLElement, 'monaco-tl-contents', 'monaco-tl-row')) {
 		target = TreeMouseEventTarget.Element;
+	} else if (hasParentWithClass(event.browserEvent.target as HTMLElement, 'bookmark-not-set', 'monaco-tl-row') ||
+		hasParentWithClass(event.browserEvent.target as HTMLElement, 'bookmark-set-workspace', 'monaco-tl-row') ||
+		hasParentWithClass(event.browserEvent.target as HTMLElement, 'bookmark-set-global', 'monaco-tl-row')) {
+		target = TreeMouseEventTarget.Bookmark;
 	}
 
 	return {

--- a/src/vs/base/browser/ui/tree/tree.ts
+++ b/src/vs/base/browser/ui/tree/tree.ts
@@ -141,7 +141,8 @@ export interface ITreeEvent<T> {
 export enum TreeMouseEventTarget {
 	Unknown,
 	Twistie,
-	Element
+	Element,
+	Bookmark
 }
 
 export interface ITreeMouseEvent<T> {

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -32,7 +32,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { ExplorerDelegate, ExplorerDataSource, FilesRenderer, ICompressedNavigationController, FilesFilter, FileSorter, FileDragAndDrop, ExplorerCompressionDelegate, isCompressedFolderName } from 'vs/workbench/contrib/scopeTree/browser/explorerViewer';
 import { IThemeService, IFileIconTheme } from 'vs/platform/theme/common/themeService';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
-import { ITreeContextMenuEvent } from 'vs/base/browser/ui/tree/tree';
+import { ITreeContextMenuEvent, TreeMouseEventTarget } from 'vs/base/browser/ui/tree/tree';
 import { IMenuService, MenuId, IMenu } from 'vs/platform/actions/common/actions';
 import { createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
@@ -361,6 +361,12 @@ export class ExplorerView extends ViewPane {
 
 			if (icon !== null) {
 				icon.style.visibility = 'hidden';
+			}
+		}));
+
+		this._register(this.tree.onMouseClick(e => {
+			if (e.target === TreeMouseEventTarget.Bookmark && e.element) {
+				this.tree.toggleCollapsed(e.element);
 			}
 		}));
 	}


### PR DESCRIPTION
Because the bookmark icon is part of the row including the name and twistie, the directory is expanded whenever a click happens on that container. To avoid this when the bookmark icon is clicked, toggle the expanded state of the directory.