### PR TITLE
Added a context menu to each panel so that bookmarks can be toggled / removed using right-click

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -126,6 +126,8 @@ export class MenuId {
 	static readonly TimelineTitle = new MenuId('TimelineTitle');
 	static readonly TimelineTitleContext = new MenuId('TimelineTitleContext');
 	static readonly AccountsContext = new MenuId('AccountsContext');
+	static readonly DisplayWorkspaceBookmarksContext = new MenuId('DisplayWorkspaceBookmarksContext');
+	static readonly DisplayGlobalBookmarksContext = new MenuId('DisplayGlobalBookmarksContext');
 
 	readonly id: number;
 	readonly _debugName: string;

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -1,0 +1,4 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -8,18 +8,81 @@ import { IBookmarksManager, BookmarkType } from 'vs/workbench/contrib/scopeTree/
 import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { Bookmark } from 'vs/workbench/contrib/scopeTree/browser/bookmarksView';
+import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
 
-const removeBookmarkHandler: ICommandHandler = (accessor, bookmark: Bookmark) => {
+// Handlers implementations for context menu actions
+const removeBookmarkHandler: ICommandHandler = (accessor, element: Bookmark) => {
+	const bookmarksManager = accessor.get(IBookmarksManager);
+	bookmarksManager.addBookmark(element.resource, BookmarkType.NONE);
 };
 
-const toggleToGlobalBookmarkHandler: ICommandHandler = (accessor, bookmark: Bookmark) => {
+const toggleToGlobalBookmarkHandler: ICommandHandler = (accessor, element: Bookmark) => {
+	const bookmarksManager = accessor.get(IBookmarksManager);
+	bookmarksManager.addBookmark(element.resource, BookmarkType.GLOBAL);
 };
 
-const toggleToWorkspaceBookmarkHandler: ICommandHandler = (accessor, bookmark: Bookmark) => {
+const toggleToWorkspaceBookmarkHandler: ICommandHandler = (accessor, element: Bookmark) => {
+	const bookmarksManager = accessor.get(IBookmarksManager);
+	bookmarksManager.addBookmark(element.resource, BookmarkType.WORKSPACE);
+};
+
+const setBookmarkAsRoot: ICommandHandler = (accessor, element: Bookmark) => {
+	const explorerService = accessor.get(IExplorerService);
+	explorerService.setRoot(element.resource);
+};
+
+const sortBookmarksByName: ICommandHandler = (accessor) => {
+	console.log('Sorting by name is not implemented');
+};
+
+const sortBookmarksByDate: ICommandHandler = (accessor) => {
+	console.log('Sorting by date is not implemented');
+};
+
+const displayBookmarkInFileTree: ICommandHandler = (accessor) => {
+	console.log('Displaying directory in file tree from bookmarks panel is not implemented');
 };
 
 // Workspace panel context menu
 MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
+	group: '1_bookmarks_sort',
+	order: 10,
+	command: {
+		id: 'sortBookmarksByName',
+		title: 'Sort by: Name'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
+	group: '1_bookmarks_sort',
+	order: 20,
+	command: {
+		id: 'sortBookmarksByDate',
+		title: 'Sort by: Date added'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
+	group: '2_bookmarks_file_tree_actions',
+	order: 10,
+	command: {
+		id: 'setBookmarkAsRoot',
+		title: 'Set as root'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
+	group: '2_bookmarks_file_tree_actions',
+	order: 20,
+	command: {
+		id: 'displayBookmarkInFileTree',
+		title: 'Show in file tree'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
+	group: '3_bookmarks_toggle',
+	order: 10,
 	command: {
 		id: 'removeBookmark',
 		title: 'Remove bookmark'
@@ -27,6 +90,8 @@ MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
 });
 
 MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
+	group: '3_bookmarks_toggle',
+	order: 20,
 	command: {
 		id: 'toggleBookmarkToGlobal',
 		title: 'Change to global bookmark'
@@ -35,6 +100,44 @@ MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
 
 // Global panel context menu
 MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
+	group: '1_bookmarks_sort',
+	order: 10,
+	command: {
+		id: 'sortBookmarksByName',
+		title: 'Sort by: Name'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
+	group: '1_bookmarks_sort',
+	order: 20,
+	command: {
+		id: 'sortBookmarksByDate',
+		title: 'Sort by: Date added'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
+	group: '2_bookmarks_file_tree_actions',
+	order: 10,
+	command: {
+		id: 'setBookmarkAsRoot',
+		title: 'Set as root'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
+	group: '2_bookmarks_file_tree_actions',
+	order: 20,
+	command: {
+		id: 'displayBookmarkInFileTree',
+		title: 'Show in file tree'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
+	group: '3_bookmarks_toggle',
+	order: 10,
 	command: {
 		id: 'removeBookmark',
 		title: 'Remove bookmark'
@@ -42,12 +145,15 @@ MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
 });
 
 MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
+	group: '3_bookmarks_toggle',
+	order: 20,
 	command: {
 		id: 'toggleBookmarkToWorkspace',
 		title: 'Change to workspace bookmark'
 	}
 });
 
+// Register commands
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'removeBookmark',
 	weight: KeybindingWeight.WorkbenchContrib,
@@ -64,4 +170,28 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'toggleBookmarkToWorkspace',
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: toggleToWorkspaceBookmarkHandler
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'setBookmarkAsRoot',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: setBookmarkAsRoot
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'sortBookmarksByName',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: sortBookmarksByName
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'sortBookmarksByDate',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: sortBookmarksByDate
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'displayBookmarkInFileTree',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: displayBookmarkInFileTree
 });

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -2,3 +2,66 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+
+import { ICommandHandler } from 'vs/platform/commands/common/commands';
+import { IBookmarksManager, BookmarkType } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
+import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
+import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { Bookmark } from 'vs/workbench/contrib/scopeTree/browser/bookmarksView';
+
+const removeBookmarkHandler: ICommandHandler = (accessor, bookmark: Bookmark) => {
+};
+
+const toggleToGlobalBookmarkHandler: ICommandHandler = (accessor, bookmark: Bookmark) => {
+};
+
+const toggleToWorkspaceBookmarkHandler: ICommandHandler = (accessor, bookmark: Bookmark) => {
+};
+
+// Workspace panel context menu
+MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
+	command: {
+		id: 'removeBookmark',
+		title: 'Remove bookmark'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayWorkspaceBookmarksContext, {
+	command: {
+		id: 'toggleBookmarkToGlobal',
+		title: 'Change to global bookmark'
+	}
+});
+
+// Global panel context menu
+MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
+	command: {
+		id: 'removeBookmark',
+		title: 'Remove bookmark'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayGlobalBookmarksContext, {
+	command: {
+		id: 'toggleBookmarkToWorkspace',
+		title: 'Change to workspace bookmark'
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'removeBookmark',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: removeBookmarkHandler
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'toggleBookmarkToGlobal',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: toggleToGlobalBookmarkHandler
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'toggleBookmarkToWorkspace',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: toggleToWorkspaceBookmarkHandler
+});

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -13,7 +13,7 @@ import { URI } from 'vs/base/common/uri';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
 // Handlers implementations for context menu actions
-const focusFileExplorer: ICommandHandler = (accessor, element: Bookmark) => {
+const changeFileExplorerRoot: ICommandHandler = (accessor, element: Bookmark) => {
 	const explorerService = accessor.get(IExplorerService);
 	explorerService.setRoot(element.resource);
 };
@@ -182,7 +182,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'setBookmarkAsRoot',
 	weight: KeybindingWeight.WorkbenchContrib,
-	handler: focusFileExplorer
+	handler: changeFileExplorerRoot
 });
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -161,6 +161,9 @@ import 'vs/workbench/contrib/scopeTree/browser/explorerViewlet';
 import 'vs/workbench/contrib/files/browser/fileActions.contribution';
 import 'vs/workbench/contrib/scopeTree/browser/files.contribution';
 
+// Bookmarks
+import 'vs/workbench/contrib/scopeTree/browser/bookmarks.contribution';
+
 // Backup
 import 'vs/workbench/contrib/backup/common/backup.contribution';
 


### PR DESCRIPTION
Created a new contribution (which is also registered in workbench.contrib). This allows us to create a context menu (which appears when the name of a directory is right-clicked) for each bookmarks panel so that bookmarks can be toggled / removed from the panel.

These context menus will also have to be added in the bookmarksView class