### PR TITLE
TO BE DELETED - Changed the data structure used to render bookmarks into a tree

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
@@ -12,9 +12,6 @@ export class BookmarksManager implements IBookmarksManager {
 	static readonly WORKSPACE_BOOKMARKS_STORAGE_KEY: string = 'workbench.explorer.bookmarksWorkspace';
 	static readonly GLOBAL_BOOKMARKS_STORAGE_KEY: string = 'workbench.explorer.bookmarksGlobal';
 
-	// Yellow bookmark = workspace
-	// Red bookmark = global
-
 	globalBookmarks: Set<string> = new Set();
 	workspaceBookmarks: Set<string> = new Set();
 

--- a/src/vs/workbench/contrib/scopeTree/browser/media/bookmarkIcon.css
+++ b/src/vs/workbench/contrib/scopeTree/browser/media/bookmarkIcon.css
@@ -34,6 +34,7 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: row;
+	padding-left: 20px;
 }
 
 .bookmark-path {
@@ -61,15 +62,7 @@
 }
 
 .bookmarks-container {
-	padding-left: 20px;
-	max-height: 50%;
-	overflow-y: scroll;
-}
-
-.bookmarks-container ul {
-	margin-top: 0px;
-	height: 100%;
-	padding: 0px;
+	height: 45%;
 }
 
 .scope-tree-focus-icon-near-bookmark {
@@ -79,16 +72,5 @@
 	visibility: hidden;
 	height: 50%;
 	padding-right: 5px;
-	padding-top: 1px;
-}
-
-::-webkit-scrollbar {
-	-webkit-appearance: none;
-	width: 7px;
-}
-
-::-webkit-scrollbar-thumb {
-	border-radius: 4px;
-	background-color: rgba(0, 0, 0, 0.096);
-	box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+	padding-top: 3px;
 }


### PR DESCRIPTION
Render the bookmarks using a tree in order to allow search in the panel and scrolling.

By default bookmarks are ordered alphabetically (by the directory name) and in case of equality, the one with a shorter path (in the number of levels) is rendered first.

This implementation is more consistent with the rest of the code and allows easier extension of the functionality (e.g. drag and drop can be implemented).