### PR TITLE
Avoid changing the view explicitly by triggering a rootChanged event when the roots change in model

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerModel.ts
@@ -50,6 +50,7 @@ export class ExplorerModel implements IDisposable {
 		});
 
 		this._roots = [root];
+		this._onDidChangeRoots.fire();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -140,9 +140,7 @@ export class ExplorerService implements IExplorerService {
 	}
 
 	setRoot(resource: URI): void {
-		this.model.setRoot(resource, this.sortOrder).then(async () => {
-			await this.view?.setTreeInput();
-		});
+		this.model.setRoot(resource, this.sortOrder);
 	}
 
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {


### PR DESCRIPTION
Rather than setting the input of the view explicitly, we can trigger a onDidChangeRoots() event from the model and this is already handled by explorerService.