### PR TITLE
Ready - Render breadcrumb between the header and body of the explorer view panel

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -314,7 +314,7 @@ export class ExplorerView extends ViewPane {
 		DOM.append(container, parentContainer);
 		DOM.append(breadcrumbBackground, this.breadcrumb);
 
-		if (this.isBodyVisible()) {
+		if (this.isExpanded()) {
 			container.parentElement?.insertBefore(breadcrumbBackground, container);
 		}
 
@@ -350,11 +350,16 @@ export class ExplorerView extends ViewPane {
 				}
 				// Find resource to focus from active editor input if set
 				this.selectActiveFile(false, true);
+			}
+		}));
+
+		this.onDidChangeExpansionState(e => {
+			if (e) {
 				container.parentElement?.insertBefore(breadcrumbBackground, container);
 			} else {
 				container.parentElement?.removeChild(breadcrumbBackground);
 			}
-		}));
+		});
 
 		this._register(this.tree.onMouseOver(e => {
 			const icon = document.getElementById('iconContainer_' + e.element?.resource.toString());

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -298,7 +298,7 @@ export class ExplorerView extends ViewPane {
 
 	protected layoutBody(height: number, width: number): void {
 		super.layoutBody(height, width);
-		this.tree.layout(height, width);
+		this.tree.layout(height - 8, width);
 	}
 
 	renderBody(container: HTMLElement): void {
@@ -306,12 +306,16 @@ export class ExplorerView extends ViewPane {
 		this.renderParentButton();
 
 		const parentContainer = document.createElement('div');
-		const breadcrumbBackround = DOM.append(parentContainer, document.createElement('div'));
+		const breadcrumbBackground = document.createElement('div');
 
 		DOM.addClass(this.breadcrumb, 'breadcrumb-file-tree');
-		DOM.addClass(breadcrumbBackround, 'breadcrumb-background');
+		DOM.addClass(breadcrumbBackground, 'breadcrumb-background');
 		DOM.append(container, parentContainer);
-		DOM.append(breadcrumbBackround, this.breadcrumb);
+		DOM.append(breadcrumbBackground, this.breadcrumb);
+
+		if (this.isBodyVisible()) {
+			container.parentElement?.insertBefore(breadcrumbBackground, container);
+		}
 
 		this.treeContainer = DOM.append(parentContainer, DOM.$('.explorer-folders-view'));
 
@@ -345,6 +349,9 @@ export class ExplorerView extends ViewPane {
 				}
 				// Find resource to focus from active editor input if set
 				this.selectActiveFile(false, true);
+				container.parentElement?.insertBefore(breadcrumbBackground, container);
+			} else {
+				container.parentElement?.removeChild(breadcrumbBackground);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -314,8 +314,9 @@ export class ExplorerView extends ViewPane {
 		DOM.append(container, parentContainer);
 		DOM.append(breadcrumbBackground, this.breadcrumb);
 
-		if (this.isExpanded()) {
-			container.parentElement?.insertBefore(breadcrumbBackground, container);
+		container.parentElement?.insertBefore(breadcrumbBackground, container);
+		if (!this.isExpanded()) {
+			DOM.hide(breadcrumbBackground);
 		}
 
 		this.treeContainer = DOM.append(parentContainer, DOM.$('.explorer-folders-view'));
@@ -355,9 +356,9 @@ export class ExplorerView extends ViewPane {
 
 		this.onDidChangeExpansionState(e => {
 			if (e) {
-				container.parentElement?.insertBefore(breadcrumbBackground, container);
+				DOM.show(breadcrumbBackground);
 			} else {
-				container.parentElement?.removeChild(breadcrumbBackground);
+				DOM.hide(breadcrumbBackground);
 			}
 		});
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -298,7 +298,7 @@ export class ExplorerView extends ViewPane {
 
 	protected layoutBody(height: number, width: number): void {
 		super.layoutBody(height, width);
-		this.tree.layout(height - 8, width);
+		this.tree.layout(height, width);
 	}
 
 	renderBody(container: HTMLElement): void {
@@ -307,6 +307,7 @@ export class ExplorerView extends ViewPane {
 
 		const parentContainer = document.createElement('div');
 		const breadcrumbBackground = document.createElement('div');
+		breadcrumbBackground.style.height = `${ExplorerDelegate.ITEM_HEIGHT}px`;
 
 		DOM.addClass(this.breadcrumb, 'breadcrumb-file-tree');
 		DOM.addClass(breadcrumbBackground, 'breadcrumb-background');

--- a/src/vs/workbench/contrib/scopeTree/browser/media/treeNavigation.css
+++ b/src/vs/workbench/contrib/scopeTree/browser/media/treeNavigation.css
@@ -15,7 +15,6 @@
 
 .breadcrumb-background {
 	background-color: #eee;
-	height: 30px;
 }
 
 .breadcrumb-element {

--- a/src/vs/workbench/contrib/scopeTree/browser/media/treeNavigation.css
+++ b/src/vs/workbench/contrib/scopeTree/browser/media/treeNavigation.css
@@ -9,6 +9,8 @@
 	position: relative;
 	left: -20px;
 	top: -10px;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .breadcrumb-background {

--- a/src/vs/workbench/contrib/scopeTree/browser/media/treeNavigation.css
+++ b/src/vs/workbench/contrib/scopeTree/browser/media/treeNavigation.css
@@ -8,10 +8,12 @@
 	white-space: nowrap;
 	position: relative;
 	left: -20px;
+	top: -10px;
 }
 
 .breadcrumb-background {
 	background-color: #eee;
+	height: 30px;
 }
 
 .breadcrumb-element {


### PR DESCRIPTION
The breadcrumb is placed here because keeping it in the body would cause issues when the file tree needs more space to render all the elements (the file tree would resize to take the whole space in the body and would be rendered over the breadcrumb).

Keeping it in the header would not work because it would be rendered next to the Actions, and it would have the same styling as this container.

Keeping it between the two works well, except that its visibility has to be manually toggled when the visibility of the body changes.