### PR TITLE
Render a new panel for recent directories

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewlet.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewlet.ts
@@ -40,6 +40,7 @@ import { AddRootFolderAction, OpenFolderAction, OpenFileFolderAction } from 'vs/
 import { isMacintosh } from 'vs/base/common/platform';
 import { Codicon } from 'vs/base/common/codicons';
 import { BookmarksView } from 'vs/workbench/contrib/scopeTree/browser/bookmarksView';
+import { RecentDirectoriesView } from 'vs/workbench/contrib/scopeTree/browser/recentDirectoriesView';
 
 export class ExplorerViewletViewsContribution extends Disposable implements IWorkbenchContribution {
 
@@ -79,6 +80,11 @@ export class ExplorerViewletViewsContribution extends Disposable implements IWor
 		const bookmarksDescriptor = this.createBookmarksViewDescriptor();
 		if (!viewDescriptors.some(v => v.id === bookmarksDescriptor.id)) {
 			viewDescriptorsToRegister.push(bookmarksDescriptor);
+		}
+
+		const recentDirectoriesDescriptor = this.createRecentDirectoriesDescriptor();
+		if (!viewDescriptors.some(v => v.id === recentDirectoriesDescriptor.id)) {
+			viewDescriptorsToRegister.push(recentDirectoriesDescriptor);
 		}
 
 		const explorerViewDescriptor = this.createExplorerViewDescriptor();
@@ -164,6 +170,16 @@ export class ExplorerViewletViewsContribution extends Disposable implements IWor
 			ctorDescriptor: new SyncDescriptor(BookmarksView),
 			order: 2,
 			canToggleVisibility: true,
+		};
+	}
+
+	private createRecentDirectoriesDescriptor(): IViewDescriptor {
+		return {
+			id: RecentDirectoriesView.ID,
+			name: RecentDirectoriesView.NAME,
+			ctorDescriptor: new SyncDescriptor(RecentDirectoriesView),
+			order: 3,
+			canToggleVisibility: true
 		};
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ViewPane } from 'vs/workbench/browser/parts/views/viewPaneContainer';
+
+export class RecentDirectoriesView extends ViewPane {
+	static readonly ID: string = 'workbench.explorer.displayRecentDirectories';
+	static readonly NAME = 'Recent directories';
+}


### PR DESCRIPTION
Create a new view (recentDirectoriesView.ts) where recent directories will be rendered. 
Add a panel for this view in explorerViewlet.ts. This is inserted as the last item in the sidebar.
The visibility of this panel can be toggled in order to avoid taking up too much space in the sidebar.
