### PR TITLE
NOT READY - Create a service in charge of the focus action because it is used in multiple places

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/breadcrumbObserver.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/breadcrumbObserver.ts
@@ -25,10 +25,6 @@ export class BreadcrumbObserver implements IBreadcrumbObserver {
 				const icon = document.getElementById('breadcrumbFocusIconContainer_' + element.resource.toString());
 				if (icon) {
 					icon.style.visibility = 'visible';
-					icon.onclick = () => {
-						const resource = element.resource;
-						this.explorerService.setRoot(resource);
-					};
 				}
 			}
 		});
@@ -50,6 +46,9 @@ export class BreadcrumbObserver implements IBreadcrumbObserver {
 		const iconContainer = document.createElement('img');
 		iconContainer.className = 'scope-tree-focus-icon';
 		iconContainer.id = 'breadcrumbFocusIconContainer_' + resource.toString();
+		iconContainer.onclick = () => {
+			this.explorerService.setRoot(resource);
+		};
 
 		const previousIcon = templateData.element.lastChild;
 		if (previousIcon && (<HTMLElement>previousIcon).className === 'scope-tree-focus-icon') {

--- a/src/vs/workbench/contrib/scopeTree/browser/breadcrumbObserver.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/breadcrumbObserver.ts
@@ -6,36 +6,31 @@
 import 'vs/css!./media/scopeTreeFileIcon';
 import { IBreadcrumbObserver } from 'vs/workbench/browser/parts/editor/breadcrumbObserver';
 import { IFileStat, FileKind } from 'vs/platform/files/common/files';
-import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
 import { IResourceLabel } from 'vs/workbench/browser/labels';
 import { URI } from 'vs/base/common/uri';
 import { Tree } from 'vs/workbench/browser/parts/editor/breadcrumbsPicker';
+import { IScopeTreeService } from 'vs/workbench/contrib/scopeTree/common/scopeTree';
 
 export class BreadcrumbObserver implements IBreadcrumbObserver {
 	declare readonly _serviceBrand: undefined;
+	private readonly locationID: string = 'breadcrumbFocusIconContainer';
 
 	constructor(
-		@IExplorerService private readonly explorerService: IExplorerService
+		@IScopeTreeService private readonly scopeTreeService: IScopeTreeService
 	) { }
 
 	registerTreeListeners(tree: Tree<any, any>): void {
 		tree.onMouseOver(e => {
 			const element = e.element as IFileStat;
 			if (element) {
-				const icon = document.getElementById('breadcrumbFocusIconContainer_' + element.resource.toString());
-				if (icon) {
-					icon.style.visibility = 'visible';
-				}
+				this.scopeTreeService.showFocusIcon(element.resource, this.locationID);
 			}
 		});
 
 		tree.onMouseOut(e => {
 			const element = e.element as IFileStat;
 			if (element) {
-				const icon = document.getElementById('breadcrumbFocusIconContainer_' + element.resource.toString());
-				if (icon) {
-					icon.style.visibility = 'hidden';
-				}
+				this.scopeTreeService.hideFocusIcon(element.resource, this.locationID);
 			}
 		});
 	}
@@ -43,15 +38,9 @@ export class BreadcrumbObserver implements IBreadcrumbObserver {
 	renderFocusIcon(resource: URI, fileKind: FileKind, templateData: IResourceLabel): void {
 		templateData.element.style.float = '';
 
-		const iconContainer = document.createElement('img');
-		iconContainer.className = 'scope-tree-focus-icon';
-		iconContainer.id = 'breadcrumbFocusIconContainer_' + resource.toString();
-		iconContainer.onclick = () => {
-			this.explorerService.setRoot(resource);
-		};
-
-		const previousIcon = templateData.element.lastChild;
-		if (previousIcon && (<HTMLElement>previousIcon).className === 'scope-tree-focus-icon') {
+		const iconContainer = this.scopeTreeService.renderFocusIcon(resource, this.locationID);
+		const previousIcon = templateData.element.lastChild as HTMLElement;
+		if (previousIcon && previousIcon.className === 'scope-tree-focus-icon') {
 			templateData.element.removeChild(previousIcon);
 		}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -29,7 +29,7 @@ import { DelayedDragHandler } from 'vs/base/browser/dnd';
 import { IEditorService, SIDE_GROUP, ACTIVE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/viewPaneContainer';
 import { ILabelService } from 'vs/platform/label/common/label';
-import { ExplorerDelegate, ExplorerDataSource, FilesRenderer, ICompressedNavigationController, FilesFilter, FileSorter, FileDragAndDrop, ExplorerCompressionDelegate, isCompressedFolderName } from 'vs/workbench/contrib/scopeTree/browser/explorerViewer';
+import { ExplorerDelegate, ExplorerDataSource, FilesRenderer, ICompressedNavigationController, FilesFilter, FileSorter, FileDragAndDrop, ExplorerCompressionDelegate, isCompressedFolderName, FocusIconRenderer } from 'vs/workbench/contrib/scopeTree/browser/explorerViewer';
 import { IThemeService, IFileIconTheme } from 'vs/platform/theme/common/themeService';
 import { IWorkbenchThemeService } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { ITreeContextMenuEvent } from 'vs/base/browser/ui/tree/tree';
@@ -57,6 +57,7 @@ import { dirname, basename } from 'vs/base/common/resources';
 import { Codicon } from 'vs/base/common/codicons';
 import 'vs/css!./media/treeNavigation';
 import { IBookmarksManager } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
+import { IScopeTreeService } from 'vs/workbench/contrib/scopeTree/common/scopeTree';
 
 interface IExplorerViewColors extends IColorMapping {
 	listDropBackground?: ColorValue | undefined;
@@ -179,7 +180,8 @@ export class ExplorerView extends ViewPane {
 		@IFileService private readonly fileService: IFileService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IOpenerService openerService: IOpenerService,
-		@IBookmarksManager private readonly bookmarksManager: IBookmarksManager
+		@IBookmarksManager private readonly bookmarksManager: IBookmarksManager,
+		@IScopeTreeService private readonly scopeTreeService: IScopeTreeService
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
 
@@ -349,18 +351,15 @@ export class ExplorerView extends ViewPane {
 		}));
 
 		this._register(this.tree.onMouseOver(e => {
-			const icon = document.getElementById('iconContainer_' + e.element?.resource.toString());
-
-			if (icon !== null) {
-				icon.style.visibility = 'visible';
+			if (e.element) {
+				this.scopeTreeService.showFocusIcon(e.element.resource, FocusIconRenderer.locationID);
+				console.log('bogdan');
 			}
 		}));
 
 		this._register(this.tree.onMouseOut(e => {
-			const icon = document.getElementById('iconContainer_' + e.element?.resource.toString());
-
-			if (icon !== null) {
-				icon.style.visibility = 'hidden';
+			if (e.element) {
+				this.scopeTreeService.hideFocusIcon(e.element.resource, FocusIconRenderer.locationID);
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/scopeTree/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/files.contribution.ts
@@ -44,6 +44,8 @@ import { BookmarksManager } from 'vs/workbench/contrib/scopeTree/browser/bookmar
 import { IBookmarksManager } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 import { BreadcrumbObserver } from 'vs/workbench/contrib/scopeTree/browser/breadcrumbObserver';
 import { IBreadcrumbObserver } from 'vs/workbench/browser/parts/editor/breadcrumbObserver';
+import { ScopeTreeService } from 'vs/workbench/contrib/scopeTree/browser/scopeTree';
+import { IScopeTreeService } from 'vs/workbench/contrib/scopeTree/common/scopeTree';
 
 // Viewlet Action
 export class OpenExplorerViewletAction extends ShowViewletAction {
@@ -81,6 +83,7 @@ class FileUriLabelContribution implements IWorkbenchContribution {
 registerSingleton(IExplorerService, ExplorerService, true);
 registerSingleton(IBookmarksManager, BookmarksManager, true);
 registerSingleton(IBreadcrumbObserver, BreadcrumbObserver, true);
+registerSingleton(IScopeTreeService, ScopeTreeService, true);
 
 const openViewletKb: IKeybindings = {
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_E

--- a/src/vs/workbench/contrib/scopeTree/browser/scopeTree.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/scopeTree.ts
@@ -1,0 +1,42 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IScopeTreeService } from 'vs/workbench/contrib/scopeTree/common/scopeTree';
+import { URI } from 'vs/base/common/uri';
+import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
+
+export class ScopeTreeService implements IScopeTreeService {
+	declare readonly _serviceBrand: undefined;
+	readonly iconName: string = 'scope-tree-focus-icon';
+
+	constructor(
+		@IExplorerService private readonly explorerService: IExplorerService
+	) { }
+
+	renderFocusIcon(resource: URI, locationID: string): HTMLElement {
+		const iconContainer = document.createElement('img');
+		iconContainer.className = 'scope-tree-focus-icon';
+		iconContainer.id = locationID + '_' + resource.toString();
+		iconContainer.onclick = () => {
+			this.explorerService.setRoot(resource);
+		};
+
+		return iconContainer;
+	}
+
+	showFocusIcon(resource: URI, locationID: string): void {
+		const icon = document.getElementById(locationID + '_' + resource.toString());
+		if (icon) {
+			icon.style.visibility = 'visible';
+		}
+	}
+
+	hideFocusIcon(resource: URI, locationID: string): void {
+		const icon = document.getElementById(locationID + '_' + resource.toString());
+		if (icon) {
+			icon.style.visibility = 'hidden';
+		}
+	}
+}

--- a/src/vs/workbench/contrib/scopeTree/common/scopeTree.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/scopeTree.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from 'vs/base/common/uri';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+export interface IScopeTreeService {
+	readonly _serviceBrand: undefined;
+	readonly iconName: string;
+	renderFocusIcon(resource: URI, locationID: string): HTMLElement;
+	showFocusIcon(resource: URI, locationID: string): void;
+	hideFocusIcon(resource: URI, locationID: string): void;
+}
+
+export const IScopeTreeService = createDecorator<IScopeTreeService>('scopeTreeService');


### PR DESCRIPTION
Create the IScopeTreeService which deals with rendering / showing / hiding the focus icon. This service can then be injected where the focus action is rendered (breadcrumbPicker, file tree panel, bookmarks panel, probably recent directories too).

This allows for better code reuse. 