### PR TITLE
Add context menu to the tree in bookmarks panel

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -344,7 +344,6 @@ export class BookmarksView extends ViewPane {
 			return;
 		}
 
-		const element = e.element;
 		const actions: IAction[] = [];
 		const disposables = new DisposableStore();
 		disposables.add(createAndFillInContextMenuActions(this.contributedContextMenu, { shouldForwardArgs: true }, actions, this.contextMenuService));
@@ -358,7 +357,7 @@ export class BookmarksView extends ViewPane {
 				}
 				disposables.dispose();
 			},
-			getActionsContext: () => element
+			getActionsContext: () => e.element
 		});
 	}
 


### PR DESCRIPTION
Added the context menu to the tree in bookmarks panel. This is triggered for right-click on either an element in the tree or the header (different handling happens in bookmarks.contribution where the commands are registered)