### PR TITLE
Ready - Add some of the functionality for recent directories

### DIFF
--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
+import { Event } from 'vs/base/common/event';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { IWorkbenchEditorConfiguration, IEditorIdentifier, IEditorInput, toResource, SideBySideEditor } from 'vs/workbench/common/editor';
 import { IFilesConfiguration as PlatformIFilesConfiguration, FileChangeType, IFileService } from 'vs/platform/files/common/files';
@@ -49,6 +50,7 @@ export interface IExplorerService {
 	setToCopy(stats: ExplorerItem[], cut: boolean): Promise<void>;
 	isCut(stat: ExplorerItem): boolean;
 	setRoot(resource: URI): void;
+	onDidChangeRoot: Event<URI[]>;
 
 	/**
 	 * Selects and reveal the file element provided by the given resource if its found in the explorer.

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -50,7 +50,7 @@ export interface IExplorerService {
 	setToCopy(stats: ExplorerItem[], cut: boolean): Promise<void>;
 	isCut(stat: ExplorerItem): boolean;
 	setRoot(resource: URI): void;
-	onDidChangeRoot: Event<URI[]>;
+	onDidChangeRoot: Event<void>;
 
 	/**
 	 * Selects and reveal the file element provided by the given resource if its found in the explorer.

--- a/src/vs/workbench/contrib/scopeTree/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/files.contribution.ts
@@ -44,6 +44,8 @@ import { BookmarksManager } from 'vs/workbench/contrib/scopeTree/browser/bookmar
 import { IBookmarksManager } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 import { BreadcrumbObserver } from 'vs/workbench/contrib/scopeTree/browser/breadcrumbObserver';
 import { IBreadcrumbObserver } from 'vs/workbench/browser/parts/editor/breadcrumbObserver';
+import { RecentDirectoriesManager } from 'vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager';
+import { IRecentDirectoriesManager } from 'vs/workbench/contrib/scopeTree/common/recentDirectories';
 
 // Viewlet Action
 export class OpenExplorerViewletAction extends ShowViewletAction {
@@ -81,6 +83,7 @@ class FileUriLabelContribution implements IWorkbenchContribution {
 registerSingleton(IExplorerService, ExplorerService, true);
 registerSingleton(IBookmarksManager, BookmarksManager, true);
 registerSingleton(IBreadcrumbObserver, BreadcrumbObserver, true);
+registerSingleton(IRecentDirectoriesManager, RecentDirectoriesManager, true);
 
 const openViewletKb: IKeybindings = {
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KEY_E

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
@@ -43,23 +43,23 @@ export class RecentDirectoriesManager implements IRecentDirectoriesManager {
 	}
 
 	private saveOpenedDirectory(resource: string): void {
-		const recentDirectoriesAsArray = Array.from(this.recentDirectories);
+		const recentDirs = Array.from(this.recentDirectories);
 
 		// Directory was already visited recently, move it to the front
 		if (this.recentDirectories.has(resource)) {
-			const elementIndex = recentDirectoriesAsArray.indexOf(resource);
-			recentDirectoriesAsArray.splice(elementIndex, 1);
-			recentDirectoriesAsArray.unshift(resource);
-			this.recentDirectories = new Set(recentDirectoriesAsArray);
+			const elementIndex = recentDirs.indexOf(resource);
+			recentDirs.splice(elementIndex, 1);
+			recentDirs.unshift(resource);
+			this.recentDirectories = new Set(recentDirs);
 			return;
 		}
 
-		recentDirectoriesAsArray.unshift(resource);
-		if (recentDirectoriesAsArray.length > this.STORAGE_SIZE) {
-			recentDirectoriesAsArray.splice(recentDirectoriesAsArray.length - 1, 1);
+		recentDirs.unshift(resource);
+		if (recentDirs.length > this.STORAGE_SIZE) {
+			recentDirs.splice(recentDirs.length - 1, 1);
 		}
 
-		this.recentDirectories = new Set(recentDirectoriesAsArray);
+		this.recentDirectories = new Set(recentDirs);
 	}
 
 	private getActiveFile(): URI | undefined {

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
@@ -49,7 +49,6 @@ export class RecentDirectoriesManager implements IRecentDirectoriesManager {
 				this.saveOpenedDirectory(root.toString());
 			});
 			this.storeRecentDirectories();
-			console.log(this.recentDirectories);
 		});
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
@@ -12,6 +12,7 @@ import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { toResource, SideBySideEditor } from 'vs/workbench/common/editor';
 import { dirname } from 'vs/base/common/resources';
+import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
 
 export class RecentDirectoriesManager implements IRecentDirectoriesManager {
 	declare readonly _serviceBrand: undefined;
@@ -26,7 +27,8 @@ export class RecentDirectoriesManager implements IRecentDirectoriesManager {
 
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
-		@IEditorService private readonly editorService: IEditorService
+		@IEditorService private readonly editorService: IEditorService,
+		@IExplorerService private readonly explorerService: IExplorerService
 	) {
 		this.retrieveRecentDirectories();
 
@@ -38,6 +40,16 @@ export class RecentDirectoriesManager implements IRecentDirectoriesManager {
 				this.saveOpenedDirectory(parentDirectory);
 				this.storeRecentDirectories();
 			}
+			console.log(this.recentDirectories);
+		});
+
+		// Mark a directory that is set as root as 'recent'
+		this.explorerService.onDidChangeRoot(roots => {
+			roots.forEach(root => {
+				this.saveOpenedDirectory(root.toString());
+			});
+			this.storeRecentDirectories();
+			console.log(this.recentDirectories);
 		});
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
@@ -37,21 +37,20 @@ export class RecentDirectoriesManager implements IRecentDirectoriesManager {
 			const resource = this.getActiveFile();
 			if (resource) {
 				const parentDirectory = dirname(resource).toString();
-				this.saveOpenedDirectory(parentDirectory);
+				this.saveRecentDirectory(parentDirectory);
 				this.storeRecentDirectories();
 			}
 		});
 
 		// Mark a directory that is set as root as 'recent'
-		this.explorerService.onDidChangeRoot(roots => {
-			roots.forEach(root => {
-				this.saveOpenedDirectory(root.toString());
-			});
+		// this.explorerService.onDidChangeRoot(roots => {
+		this.explorerService.onDidChangeRoot(() => {
+			this.explorerService.roots.forEach(root => this.saveRecentDirectory(root.resource.toString()));
 			this.storeRecentDirectories();
 		});
 	}
 
-	private saveOpenedDirectory(resource: string): void {
+	private saveRecentDirectory(resource: string): void {
 		// Directory was already visited recently, mark it as most recent by making reinserting it in the set
 		if (this.recentDirectories.has(resource)) {
 			this.recentDirectories.delete(resource);

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
@@ -10,7 +10,7 @@ import { IStorageService, StorageScope } from 'vs/platform/storage/common/storag
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { withNullAsUndefined } from 'vs/base/common/types';
-import { toResource, SideBySideEditor } from 'vs/workbench/common/editor';
+import { toResource } from 'vs/workbench/common/editor';
 import { dirname } from 'vs/base/common/resources';
 import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
 
@@ -76,7 +76,7 @@ export class RecentDirectoriesManager implements IRecentDirectoriesManager {
 			return undefined;
 		}
 
-		return withNullAsUndefined(toResource(input, { supportSideBySide: SideBySideEditor.PRIMARY }));
+		return withNullAsUndefined(toResource(input));
 	}
 
 	private retrieveRecentDirectories(): void {

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
@@ -1,0 +1,86 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IRecentDirectoriesManager } from 'vs/workbench/contrib/scopeTree/common/recentDirectories';
+import { Emitter } from 'vs/base/common/event';
+import { URI } from 'vs/base/common/uri';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
+import { withNullAsUndefined } from 'vs/base/common/types';
+import { toResource, SideBySideEditor } from 'vs/workbench/common/editor';
+import { dirname } from 'vs/base/common/resources';
+
+export class RecentDirectoriesManager implements IRecentDirectoriesManager {
+	declare readonly _serviceBrand: undefined;
+
+	readonly STORAGE_SIZE: number = 20;
+	static readonly RECENT_DIRECTORIES_STORAGE_KEY: string = 'workbench.explorer.recentDirectoriesStorageKey';
+
+	private _onOpenedDirectory = new Emitter<string>();
+	public onOpenedDirectory = this._onOpenedDirectory.event;
+
+	recentDirectories: Set<string> = new Set();
+
+	constructor(
+		@IStorageService private readonly storageService: IStorageService,
+		@IEditorService private readonly editorService: IEditorService
+	) {
+		this.retrieveRecentDirectories();
+
+		// Mark the parent of active file as a 'recent directory'
+		this.editorService.onDidActiveEditorChange(() => {
+			const resource = this.getActiveFile();
+			if (resource) {
+				const parentDirectory = dirname(resource).toString();
+				this.saveOpenedDirectory(parentDirectory);
+				this.storeRecentDirectories();
+				this._onOpenedDirectory.fire(parentDirectory);
+			}
+		});
+	}
+
+	private saveOpenedDirectory(resource: string): void {
+		const recentDirectoriesAsArray = Array.from(this.recentDirectories);
+
+		// Directory was already visited recently, move it to the front
+		if (this.recentDirectories.has(resource)) {
+			const elementIndex = recentDirectoriesAsArray.indexOf(resource);
+			recentDirectoriesAsArray.splice(elementIndex, 1);
+			recentDirectoriesAsArray.unshift(resource);
+			this.recentDirectories = new Set(recentDirectoriesAsArray);
+			return;
+		}
+
+		recentDirectoriesAsArray.unshift(resource);
+		if (recentDirectoriesAsArray.length > this.STORAGE_SIZE) {
+			recentDirectoriesAsArray.splice(recentDirectoriesAsArray.length - 1, 1);
+		}
+
+		this.recentDirectories = new Set(recentDirectoriesAsArray);
+	}
+
+	private getActiveFile(): URI | undefined {
+		const input = this.editorService.activeEditor;
+
+		if (input instanceof DiffEditorInput) {
+			return undefined;
+		}
+
+		return withNullAsUndefined(toResource(input, { supportSideBySide: SideBySideEditor.PRIMARY }));
+	}
+
+	private retrieveRecentDirectories(): void {
+		const rawRecentDirectories = this.storageService.get(RecentDirectoriesManager.RECENT_DIRECTORIES_STORAGE_KEY, StorageScope.GLOBAL);
+		if (rawRecentDirectories) {
+			const parsedRecentDirectories = JSON.parse(rawRecentDirectories) as string[];
+			this.recentDirectories = new Set(parsedRecentDirectories);
+		}
+	}
+
+	private storeRecentDirectories(): void {
+		this.storageService.store(RecentDirectoriesManager.RECENT_DIRECTORIES_STORAGE_KEY, JSON.stringify(Array.from(this.recentDirectories)), StorageScope.GLOBAL);
+	}
+}

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesManager.ts
@@ -40,7 +40,6 @@ export class RecentDirectoriesManager implements IRecentDirectoriesManager {
 				this.saveOpenedDirectory(parentDirectory);
 				this.storeRecentDirectories();
 			}
-			console.log(this.recentDirectories);
 		});
 
 		// Mark a directory that is set as root as 'recent'

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Event } from 'vs/base/common/event';
+import { Event, Emitter } from 'vs/base/common/event';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { IExplorerService, IFilesConfiguration, SortOrder, IExplorerView } from 'vs/workbench/contrib/files/common/files';
@@ -40,6 +40,9 @@ export class ExplorerService implements IExplorerService {
 	private view: IExplorerView | undefined;
 	private model: ExplorerModel;
 
+	private _onDidChangeRoot = new Emitter<URI[]>();
+	public onDidChangeRoot = this._onDidChangeRoot.event;
+
 	constructor(
 		@IFileService private fileService: IFileService,
 		@IInstantiationService private instantiationService: IInstantiationService,
@@ -73,6 +76,7 @@ export class ExplorerService implements IExplorerService {
 			if (this.view) {
 				this.view.setTreeInput();
 			}
+			this._onDidChangeRoot.fire(this.roots.map(e => e.resource));
 		}));
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -40,7 +40,7 @@ export class ExplorerService implements IExplorerService {
 	private view: IExplorerView | undefined;
 	private model: ExplorerModel;
 
-	private _onDidChangeRoot = new Emitter<URI[]>();
+	private _onDidChangeRoot = new Emitter<void>();
 	public onDidChangeRoot = this._onDidChangeRoot.event;
 
 	constructor(
@@ -76,7 +76,7 @@ export class ExplorerService implements IExplorerService {
 			if (this.view) {
 				this.view.setTreeInput();
 			}
-			this._onDidChangeRoot.fire(this.roots.map(e => e.resource));
+			this._onDidChangeRoot.fire();
 		}));
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/common/recentDirectories.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/recentDirectories.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Event } from 'vs/base/common/event';
+
+export interface IRecentDirectoriesManager {
+	readonly _serviceBrand: undefined;
+	readonly STORAGE_SIZE: number;
+
+	onOpenedDirectory: Event<string>;
+}
+
+export const IRecentDirectoriesManager = createDecorator<IRecentDirectoriesManager>('recentDirectoriesManager');

--- a/src/vs/workbench/contrib/scopeTree/common/recentDirectories.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/recentDirectories.ts
@@ -10,7 +10,7 @@ export interface IRecentDirectoriesManager {
 	readonly _serviceBrand: undefined;
 	readonly STORAGE_SIZE: number;
 
-	onOpenedDirectory: Event<string>;
+	onOpenedDirectory: Event<{ openedDir: string, replacedDir: string | undefined }>;
 }
 
 export const IRecentDirectoriesManager = createDecorator<IRecentDirectoriesManager>('recentDirectoriesManager');

--- a/src/vs/workbench/contrib/scopeTree/common/recentDirectories.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/recentDirectories.ts
@@ -11,7 +11,7 @@ export interface IRecentDirectoriesManager {
 	readonly STORAGE_SIZE: number;
 	recentDirectories: Set<string>;
 
-	onOpenedDirectory: Event<{ openedDir: string, replacedDir: string | undefined }>;
+	onRecentDirectoriesChanged: Event<void>;
 }
 
 export const IRecentDirectoriesManager = createDecorator<IRecentDirectoriesManager>('recentDirectoriesManager');

--- a/src/vs/workbench/contrib/scopeTree/common/recentDirectories.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/recentDirectories.ts
@@ -9,6 +9,7 @@ import { Event } from 'vs/base/common/event';
 export interface IRecentDirectoriesManager {
 	readonly _serviceBrand: undefined;
 	readonly STORAGE_SIZE: number;
+	recentDirectories: Set<string>;
 
 	onOpenedDirectory: Event<{ openedDir: string, replacedDir: string | undefined }>;
 }


### PR DESCRIPTION
- Recent directories are stored between sessions. 
- When a file is opened in the editor, its parent directory is marked as 'recent'.
- When a 'recent directory' is opened again, it is reinserted into the set so as to be marked as 'most recent'.
- A directory is also marked as 'recent' when it is set as root in the file tree explorer