### PR TITLE
Ready - Added functionality for rendering the list of recent directories in the recent directories panel

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -7,7 +7,7 @@ import { ICommandHandler } from 'vs/platform/commands/common/commands';
 import { IBookmarksManager, BookmarkType, bookmarkClass } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { Bookmark, BookmarkHeader } from 'vs/workbench/contrib/scopeTree/browser/bookmarksView';
+import { BookmarkHeader } from 'vs/workbench/contrib/scopeTree/browser/bookmarksView';
 import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
 import { URI } from 'vs/base/common/uri';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
@@ -16,9 +16,10 @@ import { IListService } from 'vs/platform/list/browser/listService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { getMultiSelectedResources } from 'vs/workbench/contrib/files/browser/files';
 import { AbstractTree } from 'vs/base/browser/ui/tree/abstractTree';
+import { Directory } from 'vs/workbench/contrib/scopeTree/browser/directoryViewer';
 
 // Handlers implementations for context menu actions
-const changeFileExplorerRoot: ICommandHandler = (accessor: ServicesAccessor, element: Bookmark) => {
+const changeFileExplorerRoot: ICommandHandler = (accessor: ServicesAccessor, element: Directory) => {
 	const explorerService = accessor.get(IExplorerService);
 	const listService = accessor.get(IListService);
 	const editorService = accessor.get(IEditorService);
@@ -35,8 +36,8 @@ const changeFileExplorerRoot: ICommandHandler = (accessor: ServicesAccessor, ele
 		if (lastFocusedList && lastFocusedList?.getHTMLElement() === document.activeElement) {
 			// Selection in bookmarks panel (don't allow multiple selection)
 			const currentFocus = lastFocusedList.getFocus();
-			if (lastFocusedList instanceof AbstractTree && currentFocus.every(item => item instanceof Bookmark)) {
-				const resource = currentFocus.length === 1 ? (currentFocus[0] as Bookmark).resource : undefined;
+			if (lastFocusedList instanceof AbstractTree && currentFocus.every(item => item instanceof Directory)) {
+				const resource = currentFocus.length === 1 ? (currentFocus[0] as Directory).resource : undefined;
 				if (resource) {
 					explorerService.setRoot(resource);
 				}
@@ -72,7 +73,7 @@ const toggleIconIfVisible = (resource: URI, scope: BookmarkType) => {
 	}
 };
 
-const handleBookmarksChange = (accessor: ServicesAccessor, element: Bookmark, newScope: BookmarkType) => {
+const handleBookmarksChange = (accessor: ServicesAccessor, element: Directory, newScope: BookmarkType) => {
 	const bookmarksManager = accessor.get(IBookmarksManager);
 	const resource = element.resource;
 	bookmarksManager.addBookmark(resource, newScope);
@@ -138,8 +139,8 @@ MenuRegistry.appendMenuItem(MenuId.DisplayBookmarksContext, {
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'removeBookmark',
 	weight: KeybindingWeight.WorkbenchContrib,
-	handler: (accessor: ServicesAccessor, element: Bookmark | BookmarkHeader) => {
-		if (element && element instanceof Bookmark) {
+	handler: (accessor: ServicesAccessor, element: Directory | BookmarkHeader) => {
+		if (element && element instanceof Directory) {
 			handleBookmarksChange(accessor, element, BookmarkType.NONE);
 		}
 	}
@@ -148,8 +149,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'toggleBookmarkType',
 	weight: KeybindingWeight.WorkbenchContrib,
-	handler: (accessor: ServicesAccessor, element: Bookmark | BookmarkHeader) => {
-		if (element && element instanceof Bookmark) {
+	handler: (accessor: ServicesAccessor, element: Directory | BookmarkHeader) => {
+		if (element && element instanceof Directory) {
 			const currentBookmarkType = accessor.get(IBookmarksManager).getBookmarkType(element.resource);
 			const toggledBookmarkType = currentBookmarkType === BookmarkType.WORKSPACE ? BookmarkType.GLOBAL : BookmarkType.WORKSPACE;
 			handleBookmarksChange(accessor, element, toggledBookmarkType);

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
@@ -17,8 +17,8 @@ export class BookmarksManager implements IBookmarksManager {
 	globalBookmarks: Set<string> = new Set();
 	workspaceBookmarks: Set<string> = new Set();
 
-	private _onAddedBookmark = new Emitter<{ uri: URI, bookmarkType: BookmarkType, prevBookmarkType: BookmarkType }>();
-	public onAddedBookmark = this._onAddedBookmark.event;
+	private _onBookmarksChanged = new Emitter<{ uri: URI, bookmarkType: BookmarkType, prevBookmarkType: BookmarkType }>();
+	public onBookmarksChanged = this._onBookmarksChanged.event;
 
 	private _onDidSortBookmark = new Emitter<SortType>();
 	public onDidSortBookmark = this._onDidSortBookmark.event;
@@ -65,7 +65,7 @@ export class BookmarksManager implements IBookmarksManager {
 			}
 		}
 
-		this._onAddedBookmark.fire({ uri: resource, bookmarkType: scope, prevBookmarkType: prevScope });
+		this._onBookmarksChanged.fire({ uri: resource, bookmarkType: scope, prevBookmarkType: prevScope });
 	}
 
 	public getBookmarkType(resource: URI): BookmarkType {

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -18,7 +18,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IBookmarksManager, BookmarkType } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 import { Codicon } from 'vs/base/common/codicons';
-import { dirname, basename } from 'vs/base/common/resources';
+import { basename } from 'vs/base/common/resources';
 import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
 import { IListVirtualDelegate, IKeyboardNavigationLabelProvider } from 'vs/base/browser/ui/list/list';
 import { ScrollbarVisibility } from 'vs/base/common/scrollable';
@@ -26,30 +26,11 @@ import { IDisposable, Disposable, DisposableStore } from 'vs/base/common/lifecyc
 import { WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
 import { FuzzyScore, createMatches } from 'vs/base/common/filters';
 import { ITreeRenderer, ITreeNode, ITreeElement, ITreeContextMenuEvent } from 'vs/base/browser/ui/tree/tree';
-import { IResourceLabel, ResourceLabels } from 'vs/workbench/browser/labels';
+import { ResourceLabels } from 'vs/workbench/browser/labels';
 import { IAction } from 'vs/base/common/actions';
 import { createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IMenu, IMenuService, MenuId } from 'vs/platform/actions/common/actions';
-
-export class Bookmark {
-	private _resource: URI;
-
-	constructor(path: string) {
-		this._resource = URI.parse(path);
-	}
-
-	public getName(): string {
-		return basename(this._resource);
-	}
-
-	public getParent(): string {
-		return dirname(this._resource).toString();
-	}
-
-	get resource(): URI {
-		return this._resource;
-	}
-}
+import { Directory, IDirectoryTemplateData, DirectoryElementIconRenderer, DirectoryRenderer } from 'vs/workbench/contrib/scopeTree/browser/directoryViewer';
 
 export class BookmarkHeader {
 	expanded: boolean = true;
@@ -57,15 +38,15 @@ export class BookmarkHeader {
 	constructor(readonly scope: BookmarkType) { }
 }
 
-class BookmarkDelegate implements IListVirtualDelegate<Bookmark | BookmarkHeader> {
+class BookmarkDelegate implements IListVirtualDelegate<Directory | BookmarkHeader> {
 	static readonly ITEM_HEIGHT = 22;
 
-	getHeight(element: Bookmark | BookmarkHeader): number {
+	getHeight(element: Directory | BookmarkHeader): number {
 		return BookmarkDelegate.ITEM_HEIGHT;
 	}
 
-	getTemplateId(element: Bookmark | BookmarkHeader): string {
-		if (element instanceof Bookmark) {
+	getTemplateId(element: Directory | BookmarkHeader): string {
+		if (element instanceof Directory) {
 			return BookmarkRenderer.ID;
 		}
 
@@ -73,103 +54,24 @@ class BookmarkDelegate implements IListVirtualDelegate<Bookmark | BookmarkHeader
 	}
 }
 
-interface IBookmarkTemplateData {
-	bookmarkContainer: HTMLElement;
-	label: IResourceLabel;
-	elementDisposable: IDisposable;
-}
-
 interface IBookmarkHeaderTemplateData {
 	headerContainer: HTMLElement;
 	elementDisposable: IDisposable;
 }
 
-class BookmarkElementIconRenderer implements IDisposable {
-	private _focusIcon!: HTMLElement;
-
-	constructor(private readonly container: HTMLElement,
-		private readonly stat: URI,
-		@IExplorerService private readonly explorerService: IExplorerService) {
-		this.renderFocusIcon();
-		this.addListeners();
-	}
-
-	get focusIcon(): HTMLElement {
-		return this._focusIcon;
-	}
-
-	private showIcon = () => {
-		this._focusIcon.style.visibility = 'visible';
-	};
-
-	private hideIcon = () => {
-		this._focusIcon.style.visibility = 'hidden';
-	};
-
-	private select = async () => {
-		await this.explorerService.select(this.stat, true);	// Should also expand directory
-	};
-
-	private setRoot = () => {
-		this.explorerService.setRoot(this.stat);
-	};
-
-	private addListeners(): void {
-		this.container.addEventListener('mouseover', this.showIcon);
-		this.container.addEventListener('mouseout', this.hideIcon);
-		this.container.addEventListener('dblclick', this.select);
-		this._focusIcon.addEventListener('click', this.setRoot);
-	}
-
-	private renderFocusIcon(): void {
-		this._focusIcon = document.createElement('img');
-		this._focusIcon.className = 'scope-tree-focus-icon-near-bookmark';
-		this.container.insertBefore(this._focusIcon, this.container.firstChild);
-	}
-
-	dispose(): void {
-		this._focusIcon.remove();
-		// Listeners need to be removed because container (templateData.label.element) is not removed from the DOM.
-		this.container.removeEventListener('mouseover', this.showIcon);
-		this.container.removeEventListener('mouseout', this.hideIcon);
-		this.container.removeEventListener('dblclick', this.select);
-		this._focusIcon.removeEventListener('click', this.setRoot);
-	}
-}
-
-class BookmarkRenderer implements ITreeRenderer<Bookmark, FuzzyScore, IBookmarkTemplateData> {
+class BookmarkRenderer extends DirectoryRenderer {
 	static readonly ID = 'BookmarkRenderer';
-
-	constructor(
-		private labels: ResourceLabels,
-		private readonly explorerService: IExplorerService
-	) { }
 
 	get templateId() {
 		return BookmarkRenderer.ID;
 	}
 
-	renderTemplate(container: HTMLElement): IBookmarkTemplateData {
-		const label = this.labels.create(container, { supportHighlights: true });
-		const bookmarkContainer = DOM.append(container, document.createElement('div'));
-		return { bookmarkContainer: bookmarkContainer, label: label, elementDisposable: Disposable.None };
-	}
-
-	renderElement(element: ITreeNode<Bookmark, FuzzyScore>, index: number, templateData: IBookmarkTemplateData, height: number | undefined): void {
+	renderElement(element: ITreeNode<Directory, FuzzyScore>, index: number, templateData: IDirectoryTemplateData, height: number | undefined): void {
 		templateData.elementDisposable.dispose();
 		templateData.elementDisposable = this.renderBookmark(element.element, templateData, element.filterData);
 	}
 
-	disposeTemplate(templateData: IBookmarkTemplateData): void {
-		templateData.elementDisposable.dispose();
-		templateData.label.dispose();
-	}
-
-	disposeElement(element: ITreeNode<Bookmark, FuzzyScore>, index: number, templateData: IBookmarkTemplateData, height: number | undefined): void {
-		templateData.elementDisposable.dispose();
-	}
-
-	private renderBookmark(bookmark: Bookmark, templateData: IBookmarkTemplateData, filterData: FuzzyScore | undefined): IDisposable {
+	private renderBookmark(bookmark: Directory, templateData: IDirectoryTemplateData, filterData: FuzzyScore | undefined): IDisposable {
 		templateData.label.setResource({
 			resource: bookmark.resource,
 			name: bookmark.getName(),
@@ -178,7 +80,7 @@ class BookmarkRenderer implements ITreeRenderer<Bookmark, FuzzyScore, IBookmarkT
 			matches: createMatches(filterData)
 		});
 
-		return new BookmarkElementIconRenderer(templateData.label.element, bookmark.resource, this.explorerService);
+		return new DirectoryElementIconRenderer(templateData.label.element, bookmark.resource, this.explorerService);
 	}
 }
 
@@ -246,13 +148,13 @@ export class BookmarksView extends ViewPane {
 	static readonly NAME = 'Bookmarks';
 
 	private labels!: ResourceLabels;
-	private tree!: WorkbenchObjectTree<Bookmark | BookmarkHeader, FuzzyScore>;
+	private tree!: WorkbenchObjectTree<Directory | BookmarkHeader, FuzzyScore>;
 
 	private globalBookmarksHeader = new BookmarkHeader(BookmarkType.GLOBAL);
 	private workspaceBookmarksHeader = new BookmarkHeader(BookmarkType.WORKSPACE);
 
-	private globalBookmarks: ITreeElement<Bookmark>[] = [];
-	private workspaceBookmarks: ITreeElement<Bookmark>[] = [];
+	private globalBookmarks: ITreeElement<Directory>[] = [];
+	private workspaceBookmarks: ITreeElement<Directory>[] = [];
 
 	private contributedContextMenu!: IMenu;
 
@@ -314,8 +216,8 @@ export class BookmarksView extends ViewPane {
 		this.tree.layout(height, width);
 	}
 
-	private createTree(container: HTMLElement): WorkbenchObjectTree<Bookmark | BookmarkHeader, FuzzyScore> {
-		return <WorkbenchObjectTree<Bookmark | BookmarkHeader, FuzzyScore>>this.instantiationService.createInstance(
+	private createTree(container: HTMLElement): WorkbenchObjectTree<Directory | BookmarkHeader, FuzzyScore> {
+		return <WorkbenchObjectTree<Directory | BookmarkHeader, FuzzyScore>>this.instantiationService.createInstance(
 			WorkbenchObjectTree,
 			'BookmarksPane',
 			container,
@@ -323,8 +225,8 @@ export class BookmarksView extends ViewPane {
 			[new BookmarkRenderer(this.labels, this.explorerService), new BookmarkHeaderRenderer()],
 			{
 				accessibilityProvider: {
-					getAriaLabel(element: Bookmark | BookmarkHeader): string {
-						if (element instanceof Bookmark) {
+					getAriaLabel(element: Directory | BookmarkHeader): string {
+						if (element instanceof Directory) {
 							return element.resource.toString();
 						}
 
@@ -339,7 +241,7 @@ export class BookmarksView extends ViewPane {
 			});
 	}
 
-	private onContextMenu(e: ITreeContextMenuEvent<Bookmark | BookmarkHeader | null>): void {
+	private onContextMenu(e: ITreeContextMenuEvent<Directory | BookmarkHeader | null>): void {
 		if (!e.element) {
 			return;
 		}
@@ -370,11 +272,11 @@ export class BookmarksView extends ViewPane {
 		});
 	}
 
-	private getBookmarksTreeElements(rawBookmarks: Set<string>, treeElements: ITreeElement<Bookmark>[]) {
+	private getBookmarksTreeElements(rawBookmarks: Set<string>, treeElements: ITreeElement<Directory>[]) {
 		const sortedBookmarks = this.sortBookmarkByName(rawBookmarks);
 		for (let i = 0; i < sortedBookmarks.length; i++) {
 			treeElements.push({
-				element: new Bookmark(sortedBookmarks[i])
+				element: new Directory(sortedBookmarks[i])
 			});
 		}
 	}
@@ -394,14 +296,14 @@ export class BookmarksView extends ViewPane {
 		}
 
 		if (scope === BookmarkType.WORKSPACE) {
-			this.workspaceBookmarks.splice(0, 0, { element: new Bookmark(resourceAsString) });
+			this.workspaceBookmarks.splice(0, 0, { element: new Directory(resourceAsString) });
 			if (this.workspaceBookmarksHeader.expanded) {
 				this.tree.setChildren(this.workspaceBookmarksHeader, this.workspaceBookmarks);
 			}
 		}
 
 		if (scope === BookmarkType.GLOBAL) {
-			this.globalBookmarks.splice(0, 0, { element: new Bookmark(resourceAsString) });
+			this.globalBookmarks.splice(0, 0, { element: new Directory(resourceAsString) });
 			if (this.globalBookmarksHeader.expanded) {
 				this.tree.setChildren(this.globalBookmarksHeader, this.globalBookmarks);
 			}
@@ -425,9 +327,9 @@ export class BookmarksView extends ViewPane {
 	}
 }
 
-class BookmarkKeyboardNavigationLabelProvider implements IKeyboardNavigationLabelProvider<Bookmark | BookmarkHeader> {
-	getKeyboardNavigationLabel(element: Bookmark | BookmarkHeader): string | undefined {
-		if (element instanceof Bookmark) {
+class BookmarkKeyboardNavigationLabelProvider implements IKeyboardNavigationLabelProvider<Directory | BookmarkHeader> {
+	getKeyboardNavigationLabel(element: Directory | BookmarkHeader): string | undefined {
+		if (element instanceof Directory) {
 			return element.getName();
 		}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -178,7 +178,7 @@ export class BookmarksView extends ViewPane {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
 
 		this.labels = this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this.onDidChangeBodyVisibility });
-		this._register(this.bookmarksManager.onAddedBookmark(e => {
+		this._register(this.bookmarksManager.onBookmarksChanged(e => {
 			const resource = e.uri;
 			const prevScope = e.prevBookmarkType;
 			const newScope = e.bookmarkType;

--- a/src/vs/workbench/contrib/scopeTree/browser/directoryViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/directoryViewer.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from 'vs/base/common/uri';
+import * as DOM from 'vs/base/browser/dom';
+import { dirname, basename } from 'vs/base/common/resources';
+import { IResourceLabel, ResourceLabels } from 'vs/workbench/browser/labels';
+import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
+import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
+import { ITreeRenderer, ITreeNode } from 'vs/base/browser/ui/tree/tree';
+import { FuzzyScore } from 'vs/base/common/filters';
+
+export class Directory {
+	private _resource: URI;
+
+	constructor(path: string) {
+		this._resource = URI.parse(path);
+	}
+
+	public getName(): string {
+		return basename(this._resource);
+	}
+
+	public getParent(): string {
+		return dirname(this._resource).toString();
+	}
+
+	get resource(): URI {
+		return this._resource;
+	}
+}
+
+export interface IDirectoryTemplateData {
+	dirContainer: HTMLElement;
+	label: IResourceLabel;
+	elementDisposable: IDisposable;
+}
+
+export class DirectoryElementIconRenderer implements IDisposable {
+	private _focusIcon!: HTMLElement;
+
+	constructor(protected readonly container: HTMLElement,
+		protected readonly stat: URI,
+		@IExplorerService protected readonly explorerService: IExplorerService) {
+		this.renderFocusIcon();
+		this.addListeners();
+	}
+
+	get focusIcon(): HTMLElement {
+		return this._focusIcon;
+	}
+
+	private showIcon = () => {
+		this._focusIcon.style.visibility = 'visible';
+	};
+
+	private hideIcon = () => {
+		this._focusIcon.style.visibility = 'hidden';
+	};
+
+	private select = async () => {
+		await this.explorerService.select(this.stat, true);	// Should also expand directory
+	};
+
+	private setRoot = () => {
+		this.explorerService.setRoot(this.stat);
+	};
+
+	private addListeners(): void {
+		this.container.addEventListener('mouseover', this.showIcon);
+		this.container.addEventListener('mouseout', this.hideIcon);
+		this.container.addEventListener('dblclick', this.select);
+		this._focusIcon.addEventListener('click', this.setRoot);
+	}
+
+	private renderFocusIcon(): void {
+		this._focusIcon = document.createElement('img');
+		this._focusIcon.className = 'scope-tree-focus-icon-near-bookmark';
+		this.container.insertBefore(this._focusIcon, this.container.firstChild);
+	}
+
+	dispose(): void {
+		this._focusIcon.remove();
+		// Listeners need to be removed because container (templateData.label.element) is not removed from the DOM.
+		this.container.removeEventListener('mouseover', this.showIcon);
+		this.container.removeEventListener('mouseout', this.hideIcon);
+		this.container.removeEventListener('dblclick', this.select);
+		this._focusIcon.removeEventListener('click', this.setRoot);
+	}
+}
+
+export abstract class DirectoryRenderer implements ITreeRenderer<Directory, FuzzyScore, IDirectoryTemplateData> {
+	constructor(
+		protected labels: ResourceLabels,
+		protected readonly explorerService: IExplorerService
+	) { }
+
+	abstract get templateId(): string;
+
+	renderTemplate(container: HTMLElement): IDirectoryTemplateData {
+		const label = this.labels.create(container, { supportHighlights: true });
+		const dirContainer = DOM.append(container, document.createElement('div'));
+		return { dirContainer: dirContainer, label: label, elementDisposable: Disposable.None };
+	}
+
+	abstract renderElement(element: ITreeNode<Directory, FuzzyScore>, index: number, templateData: IDirectoryTemplateData, height: number | undefined): void;
+
+	disposeTemplate(templateData: IDirectoryTemplateData): void {
+		templateData.elementDisposable.dispose();
+		templateData.label.dispose();
+	}
+
+	disposeElement(element: ITreeNode<Directory, FuzzyScore>, index: number, templateData: IDirectoryTemplateData, height: number | undefined): void {
+		templateData.elementDisposable.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -67,7 +67,7 @@ class RecentDirectoryElementIconRenderer extends DirectoryElementIconRenderer {
 		};
 
 		if (bookmarkType === BookmarkType.NONE) {
-			this._bookmarkIcon.style.opacity = '0';
+			this._bookmarkIcon.style.visibility = 'hidden';
 		}
 
 		if (this.container.firstChild) {
@@ -192,14 +192,14 @@ export class RecentDirectoriesView extends ViewPane {
 		this._register(this.tree.onMouseOver(e => {
 			const bookmarkIcon = document.getElementById('bookmarkIconRecentDirectoryContainer_' + e.element?.resource.toString());
 			if (bookmarkIcon && e.element && this.bookmarksManager.getBookmarkType(e.element.resource) === BookmarkType.NONE) {
-				bookmarkIcon.style.opacity = '1';
+				bookmarkIcon.style.visibility = 'visible';
 			}
 		}));
 
 		this._register(this.tree.onMouseOut(e => {
 			const bookmarkIcon = document.getElementById('bookmarkIconRecentDirectoryContainer_' + e.element?.resource.toString());
 			if (bookmarkIcon && e.element && this.bookmarksManager.getBookmarkType(e.element.resource) === BookmarkType.NONE) {
-				bookmarkIcon.style.opacity = '0';
+				bookmarkIcon.style.visibility = 'hidden';
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -3,9 +3,310 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import 'vs/css!./media/bookmarkIcon';
+import * as DOM from 'vs/base/browser/dom';
 import { ViewPane } from 'vs/workbench/browser/parts/views/viewPaneContainer';
+import { IRecentDirectoriesManager } from 'vs/workbench/contrib/scopeTree/common/recentDirectories';
+import { IViewDescriptorService } from 'vs/workbench/common/views';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IMenuService, IMenu } from 'vs/platform/actions/common/actions';
+import { URI } from 'vs/base/common/uri';
+import { dirname, basename } from 'vs/base/common/resources';
+import { IListVirtualDelegate, IKeyboardNavigationLabelProvider } from 'vs/base/browser/ui/list/list';
+import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
+import { ResourceLabels, IResourceLabel } from 'vs/workbench/browser/labels';
+import { ScrollbarVisibility } from 'vs/base/common/scrollable';
+import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
+import { WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
+import { createMatches, FuzzyScore } from 'vs/base/common/filters';
+import { ITreeRenderer, ITreeNode, ITreeElement } from 'vs/base/browser/ui/tree/tree';
+import { bookmarkClass, IBookmarksManager, BookmarkType } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
+
+class RecentDirectory {
+	public resource: URI;
+
+	constructor(path: string) {
+		this.resource = URI.parse(path);
+	}
+
+	public getName(): string {
+		return basename(this.resource);
+	}
+
+	public getParent(): string {
+		return dirname(this.resource).toString();
+	}
+}
+
+export class DirectoryDelegate implements IListVirtualDelegate<RecentDirectory> {
+	static readonly ITEM_HEIGHT = 22;
+
+	getHeight(element: RecentDirectory): number {
+		return DirectoryDelegate.ITEM_HEIGHT;
+	}
+
+	getTemplateId(element: RecentDirectory): string {
+		return 'RecentDirectoriesRenderer';
+	}
+}
+
+interface IDirectoryTemplateData {
+	dirContainer: HTMLElement;
+	label: IResourceLabel;
+	elementDisposable: IDisposable;
+}
+
+class DirectoryElementIconRenderer implements IDisposable {
+	private _focusIcon!: HTMLElement;
+	private _bookmarkIcon!: HTMLElement;
+
+	constructor(private readonly container: HTMLElement,
+		private readonly stat: URI,
+		private readonly explorerService: IExplorerService,
+		private readonly bookmarksManager: IBookmarksManager) {
+		this.renderBookmarkIcon();
+		this.renderFocusIcon();
+		this.addListeners();
+	}
+
+	get focusIcon(): HTMLElement {
+		return this._focusIcon;
+	}
+
+	get bookmarkIcon(): HTMLElement {
+		return this._bookmarkIcon;
+	}
+
+	private showIcon = () => {
+		this._focusIcon.style.visibility = 'visible';
+	};
+
+	private hideIcon = () => {
+		this._focusIcon.style.visibility = 'hidden';
+	};
+
+	private select = async () => {
+		await this.explorerService.select(this.stat, true);	// Should also expand directory
+	};
+
+	private setRoot = () => {
+		this.explorerService.setRoot(this.stat);
+	};
+
+	private addListeners(): void {
+		this.container.addEventListener('mouseover', this.showIcon);
+		this.container.addEventListener('mouseout', this.hideIcon);
+		this.container.addEventListener('dblclick', this.select);
+		this._focusIcon.addEventListener('click', this.setRoot);
+	}
+
+	private renderFocusIcon(): void {
+		this._focusIcon = document.createElement('img');
+		this._focusIcon.className = 'scope-tree-focus-icon-near-bookmark';
+		this._focusIcon.style.paddingLeft = '5px';
+		this.container.insertBefore(this._focusIcon, this.container.firstChild);
+	}
+
+	private renderBookmarkIcon(): void {
+		const bookmarkType = this.bookmarksManager.getBookmarkType(this.stat);
+		this._bookmarkIcon = document.createElement('img');
+		this._bookmarkIcon.id = 'bookmarkIconRecentDirectoryContainer_' + this.stat.toString();
+		this._bookmarkIcon.className = bookmarkClass(bookmarkType);
+		this._bookmarkIcon.onclick = () => {
+			const newType = this.bookmarksManager.toggleBookmarkType(this.stat);
+			this._bookmarkIcon.className = bookmarkClass(newType);
+		};
+
+		if (bookmarkType === BookmarkType.NONE) {
+			this._bookmarkIcon.style.opacity = '0';
+		}
+
+		this.container.insertBefore(this._bookmarkIcon, this.container.firstChild);
+	}
+
+	dispose(): void {
+		this._focusIcon.remove();
+		this._bookmarkIcon.remove();
+		// Listeners need to be removed because container (templateData.label.element) is not removed from the DOM.
+		this.container.removeEventListener('mouseover', this.showIcon);
+		this.container.removeEventListener('mouseout', this.hideIcon);
+		this.container.removeEventListener('dblclick', this.select);
+		this._focusIcon.removeEventListener('click', this.setRoot);
+	}
+}
+
+class DirectoryRenderer implements ITreeRenderer<RecentDirectory, FuzzyScore, IDirectoryTemplateData> {
+	static readonly ID = 'RecentDirectoriesRenderer';
+
+	constructor(
+		private labels: ResourceLabels,
+		private readonly explorerService: IExplorerService,
+		private readonly bookmarksManager: IBookmarksManager
+	) { }
+
+	get templateId() {
+		return DirectoryRenderer.ID;
+	}
+
+	renderTwistie(element: RecentDirectory, twistieElement: HTMLElement): void {
+		// Even though the twistie is not visible, it causes some extra padding so it should be removed
+		twistieElement.remove();
+	}
+
+	renderTemplate(container: HTMLElement): IDirectoryTemplateData {
+		const label = this.labels.create(container, { supportHighlights: true });
+		const dirContainer = DOM.append(container, document.createElement('div'));
+		return { dirContainer: dirContainer, label: label, elementDisposable: Disposable.None };
+	}
+
+	renderElement(element: ITreeNode<RecentDirectory, FuzzyScore>, index: number, templateData: IDirectoryTemplateData, height: number | undefined): void {
+		templateData.elementDisposable.dispose();
+		templateData.elementDisposable = this.renderRecentDirectory(element.element, templateData, element.filterData);
+	}
+
+	disposeTemplate(templateData: IDirectoryTemplateData): void {
+		templateData.elementDisposable.dispose();
+		templateData.label.dispose();
+	}
+
+	private renderRecentDirectory(dir: RecentDirectory, templateData: IDirectoryTemplateData, filterData: FuzzyScore | undefined): IDisposable {
+		templateData.label.setResource({
+			resource: dir.resource,
+			name: dir.getName(),
+			description: dir.getParent().toString()
+		}, {
+			matches: createMatches(filterData)
+		});
+
+		return new DirectoryElementIconRenderer(templateData.label.element, dir.resource, this.explorerService, this.bookmarksManager);
+	}
+}
 
 export class RecentDirectoriesView extends ViewPane {
 	static readonly ID: string = 'workbench.explorer.displayRecentDirectories';
 	static readonly NAME = 'Recent directories';
+
+	private labels!: ResourceLabels;
+	private tree!: WorkbenchObjectTree<RecentDirectory>;
+
+	private dirs: ITreeElement<RecentDirectory>[] = [];
+
+	private contributedContextMenu!: IMenu;
+
+	constructor(
+		options: IViewletViewOptions,
+		@IThemeService themeService: IThemeService,
+		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IOpenerService openerService: IOpenerService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IMenuService private readonly menuService: IMenuService,
+		@IRecentDirectoriesManager private readonly recentDirectoriesManager: IRecentDirectoriesManager,
+		@IExplorerService private readonly explorerService: IExplorerService,
+		@IBookmarksManager private readonly bookmarksManager: IBookmarksManager
+	) {
+		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
+
+		this._register(this.recentDirectoriesManager.onOpenedDirectory(e => {
+			const openedDir = e.openedDir;
+			const replacedDir = e.replacedDir;
+			if (replacedDir) {
+				this.removeDirectory(replacedDir);
+			}
+			this.renderNewDir(openedDir);
+		}));
+
+		this._register(this.bookmarksManager.onAddedBookmark(e => {
+			if (this.dirs.find(dir => dir.element.resource.toString() === e.uri.toString())) {
+				const bookmarkIcon = document.getElementById('bookmarkIconRecentDirectoryContainer_' + e.uri.toString());
+				if (bookmarkIcon) {
+					bookmarkIcon.className = bookmarkClass(e.bookmarkType);
+					if (e.bookmarkType === BookmarkType.NONE) {
+						bookmarkIcon.style.opacity = '0';
+					} else {
+						bookmarkIcon.style.opacity = '1';
+					}
+				}
+			}
+		}));
+	}
+
+	renderBody(container: HTMLElement): void {
+		super.renderBody(container);
+
+		this.labels = this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this.onDidChangeBodyVisibility });
+		this.tree = <WorkbenchObjectTree<RecentDirectory>>this.instantiationService.createInstance(WorkbenchObjectTree, 'RecentDirectories', container,
+			new DirectoryDelegate(), [new DirectoryRenderer(this.labels, this.explorerService, this.bookmarksManager)],
+			{
+				accessibilityProvider: {
+					getAriaLabel(element: RecentDirectory) {
+						return element.resource.toString();
+					},
+
+					getWidgetAriaLabel() {
+						return 'Recent Directories';
+					}
+				},
+				verticalScrollMode: ScrollbarVisibility.Auto,
+				keyboardNavigationLabelProvider: new RecentDirectoriesKeyboardNavigationLabelProvider()
+			});
+		this._register(this.labels);
+		this._register(this.tree);
+
+		this.getDirectoriesTreeElement(this.recentDirectoriesManager.recentDirectories);
+		this.tree.setChildren(null, this.dirs);
+
+		this._register(this.tree.onMouseOver(e => {
+			const bookmarkIcon = document.getElementById('bookmarkIconRecentDirectoryContainer_' + e.element?.resource.toString());
+			if (bookmarkIcon && e.element && this.bookmarksManager.getBookmarkType(e.element.resource) === BookmarkType.NONE) {
+				bookmarkIcon.style.opacity = '1';
+			}
+		}));
+
+		this._register(this.tree.onMouseOut(e => {
+			const bookmarkIcon = document.getElementById('bookmarkIconRecentDirectoryContainer_' + e.element?.resource.toString());
+			if (bookmarkIcon && e.element && this.bookmarksManager.getBookmarkType(e.element.resource) === BookmarkType.NONE) {
+				bookmarkIcon.style.opacity = '0';
+			}
+		}));
+	}
+
+	protected layoutBody(height: number, width: number): void {
+		super.layoutBody(height, width);
+		this.tree.layout(height, width);
+	}
+
+	private getDirectoriesTreeElement(rawDirs: Set<string>) {
+		rawDirs.forEach(path => this.dirs.push({
+			element: new RecentDirectory(path)
+		}));
+	}
+
+	private renderNewDir(resource: string): void {
+		this.dirs.splice(0, 0, { element: new RecentDirectory(resource) });
+		this.tree.setChildren(null, this.dirs);
+	}
+
+	private removeDirectory(resource: string) {
+		this.dirs = this.dirs.filter(e => e.element.resource.toString() !== resource);
+		this.tree.setChildren(null, this.dirs);
+	}
+}
+
+class RecentDirectoriesKeyboardNavigationLabelProvider implements IKeyboardNavigationLabelProvider<RecentDirectory> {
+	getKeyboardNavigationLabel(element: RecentDirectory): string {
+		return element.getName();
+	}
 }

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -216,9 +216,10 @@ export class RecentDirectoriesView extends ViewPane {
 
 	private getDirectoriesTreeElement(rawDirs: Set<string>) {
 		this.dirs = [];
-		rawDirs.forEach(path => this.dirs.unshift({
+		rawDirs.forEach(path => this.dirs.push({
 			element: new Directory(path)
 		}));
+		this.dirs.reverse();
 	}
 }
 

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -150,7 +150,7 @@ export class RecentDirectoriesView extends ViewPane {
 
 		this._register(this.recentDirectoriesManager.onRecentDirectoriesChanged(() => this.refreshView()));
 
-		this._register(this.bookmarksManager.onAddedBookmark(e => {
+		this._register(this.bookmarksManager.onBookmarksChanged(e => {
 			if (this.dirs.find(dir => dir.element.resource.toString() === e.uri.toString())) {
 				const bookmarkIcon = document.getElementById('bookmarkIconRecentDirectoryContainer_' + e.uri.toString());
 				if (bookmarkIcon) {

--- a/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
@@ -17,7 +17,7 @@ export interface IBookmarksManager {
 	toggleBookmarkType(resource: URI): BookmarkType;
 	sortBookmarks(sortType: SortType): void;
 
-	onAddedBookmark: Event<{ uri: URI, bookmarkType: BookmarkType, prevBookmarkType: BookmarkType }>;
+	onBookmarksChanged: Event<{ uri: URI, bookmarkType: BookmarkType, prevBookmarkType: BookmarkType }>;
 	onDidSortBookmark: Event<SortType>;
 }
 


### PR DESCRIPTION
Recent directories are stored in a tree data structure to allow search.

From the recent directories panel, a user can set a dir as root and add / toggle a bookmark.
Dbl click on a directory focuses it in the file explorer.

Handling of recent directories after rendering is implemented.

If a directory does not have a bookmark set, the star outline only appears on mouse hover (this will also be implemented in the file tree).