### PR TITLE
Ready - Implemented sort by name and sort by date for the bookmarks panel

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ICommandHandler } from 'vs/platform/commands/common/commands';
-import { IBookmarksManager, BookmarkType, bookmarkClass } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
+import { IBookmarksManager, BookmarkType, bookmarkClass, SortType } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { Bookmark, BookmarkHeader } from 'vs/workbench/contrib/scopeTree/browser/bookmarksView';
@@ -54,11 +54,11 @@ const changeFileExplorerRoot: ICommandHandler = (accessor: ServicesAccessor, ele
 };
 
 const sortBookmarksByName: ICommandHandler = (accessor: ServicesAccessor) => {
-	console.log('Sorting by name is not implemented');
+	accessor.get(IBookmarksManager).sortBookmarks(SortType.NAME);
 };
 
 const sortBookmarksByDate: ICommandHandler = (accessor: ServicesAccessor) => {
-	console.log('Sorting by date is not implemented');
+	accessor.get(IBookmarksManager).sortBookmarks(SortType.DATE);
 };
 
 const displayBookmarkInFileTree: ICommandHandler = (accessor: ServicesAccessor) => {

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -61,8 +61,10 @@ const sortBookmarksByDate: ICommandHandler = (accessor: ServicesAccessor) => {
 	accessor.get(IBookmarksManager).sortBookmarks(SortType.DATE);
 };
 
-const displayBookmarkInFileTree: ICommandHandler = (accessor: ServicesAccessor) => {
-	console.log('Displaying directory in file tree from bookmarks panel is not implemented');
+const displayBookmarkInFileTree: ICommandHandler = (accessor: ServicesAccessor, element: Bookmark | BookmarkHeader) => {
+	if (element && element instanceof Bookmark) {
+		accessor.get(IExplorerService).select(element.resource);
+	}
 };
 
 const toggleIconIfVisible = (resource: URI, scope: BookmarkType) => {

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
@@ -34,38 +34,32 @@ export class BookmarksManager implements IBookmarksManager {
 		const resourceAsString = resource.toString();
 		let prevScope = BookmarkType.NONE;	// Undefined if bookmark already had the appropriate type
 
+		// Bookmarks are deleted even they have to be added again in order to preserve ordering by 'date added', with most recent being the last inserted
 		if (scope === BookmarkType.GLOBAL) {
 			if (this.globalBookmarks.delete(resourceAsString)) {
 				prevScope = BookmarkType.GLOBAL;
+			} else if (this.workspaceBookmarks.delete(resourceAsString)) {
+				this.saveWorkspaceBookmarks();
+				prevScope = BookmarkType.WORKSPACE;
 			}
 
 			this.globalBookmarks.add(resourceAsString);
 			this.saveGlobalBookmarks();
-
-			if (this.workspaceBookmarks.delete(resourceAsString)) {
-				this.saveWorkspaceBookmarks();
-				prevScope = BookmarkType.WORKSPACE;
-			}
 		} else if (scope === BookmarkType.WORKSPACE) {
 			if (this.workspaceBookmarks.delete(resourceAsString)) {
 				prevScope = BookmarkType.WORKSPACE;
+			} else if (this.globalBookmarks.delete(resourceAsString)) {
+				this.saveGlobalBookmarks();
+				prevScope = BookmarkType.GLOBAL;
 			}
 
 			this.workspaceBookmarks.add(resourceAsString);
 			this.saveWorkspaceBookmarks();
-
-			if (this.globalBookmarks.delete(resourceAsString)) {
-				this.saveGlobalBookmarks();
-				prevScope = BookmarkType.GLOBAL;
-			}
-
 		} else {
 			if (this.globalBookmarks.delete(resourceAsString)) {
 				this.saveGlobalBookmarks();
 				prevScope = BookmarkType.GLOBAL;
-			}
-
-			if (this.workspaceBookmarks.delete(resourceAsString)) {
+			} else if (this.workspaceBookmarks.delete(resourceAsString)) {
 				this.saveWorkspaceBookmarks();
 				prevScope = BookmarkType.WORKSPACE;
 			}

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -372,7 +372,7 @@ export class BookmarksView extends ViewPane {
 		});
 	}
 
-	private sortBookmarkByName(bookmarks: string[]): string[] {
+	private sortBookmarkByName(bookmarks: Set<string>): string[] {
 		return Array.from(bookmarks).sort((path1: string, path2: string) => {
 			const compare = basename(URI.parse(path1)).localeCompare(basename(URI.parse(path2)));
 
@@ -381,8 +381,8 @@ export class BookmarksView extends ViewPane {
 		});
 	}
 
-	private getBookmarksTreeElements(rawBookmarks: string[], sortType: SortType): ITreeElement<Bookmark>[] {
-		const sortedBookmarks = sortType === SortType.NAME ? this.sortBookmarkByName(rawBookmarks) : rawBookmarks;
+	private getBookmarksTreeElements(rawBookmarks: Set<string>, sortType: SortType): ITreeElement<Bookmark>[] {
+		const sortedBookmarks = sortType === SortType.NAME ? this.sortBookmarkByName(rawBookmarks) : Array.from(rawBookmarks).reverse();
 		const treeElements: ITreeElement<Bookmark>[] = [];
 		for (let i = 0; i < sortedBookmarks.length; i++) {
 			treeElements.push({

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -382,6 +382,7 @@ export class BookmarksView extends ViewPane {
 	}
 
 	private getBookmarksTreeElements(rawBookmarks: Set<string>, sortType: SortType): ITreeElement<Bookmark>[] {
+		// Order has to be revesed when bookmarks are sorted by date because bookmarksManager keeps the most recent at the end of the array
 		const sortedBookmarks = sortType === SortType.NAME ? this.sortBookmarkByName(rawBookmarks) : Array.from(rawBookmarks).reverse();
 		const treeElements: ITreeElement<Bookmark>[] = [];
 		for (let i = 0; i < sortedBookmarks.length; i++) {

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -372,7 +372,7 @@ export class BookmarksView extends ViewPane {
 		});
 	}
 
-	private sortBookmarkByName(bookmarks: Set<string>) {
+	private sortBookmarkByName(bookmarks: string[]): string[] {
 		return Array.from(bookmarks).sort((path1: string, path2: string) => {
 			const compare = basename(URI.parse(path1)).localeCompare(basename(URI.parse(path2)));
 
@@ -381,8 +381,8 @@ export class BookmarksView extends ViewPane {
 		});
 	}
 
-	private getBookmarksTreeElements(rawBookmarks: Set<string>, sortType: SortType): ITreeElement<Bookmark>[] {
-		const sortedBookmarks = sortType === SortType.NAME ? this.sortBookmarkByName(rawBookmarks) : Array.from(rawBookmarks);
+	private getBookmarksTreeElements(rawBookmarks: string[], sortType: SortType): ITreeElement<Bookmark>[] {
+		const sortedBookmarks = sortType === SortType.NAME ? this.sortBookmarkByName(rawBookmarks) : rawBookmarks;
 		const treeElements: ITreeElement<Bookmark>[] = [];
 		for (let i = 0; i < sortedBookmarks.length; i++) {
 			treeElements.push({

--- a/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
@@ -9,8 +9,8 @@ import { URI } from 'vs/base/common/uri';
 
 export interface IBookmarksManager {
 	readonly _serviceBrand: undefined;
-	readonly globalBookmarks: string[];
-	readonly workspaceBookmarks: string[];
+	readonly globalBookmarks: Set<string>;
+	readonly workspaceBookmarks: Set<string>;
 
 	addBookmark(resource: URI, scope: BookmarkType): void;
 	getBookmarkType(resource: URI): BookmarkType;

--- a/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
@@ -9,8 +9,8 @@ import { URI } from 'vs/base/common/uri';
 
 export interface IBookmarksManager {
 	readonly _serviceBrand: undefined;
-	readonly globalBookmarks: Set<string>;
-	readonly workspaceBookmarks: Set<string>;
+	readonly globalBookmarks: string[];
+	readonly workspaceBookmarks: string[];
 
 	addBookmark(resource: URI, scope: BookmarkType): void;
 	getBookmarkType(resource: URI): BookmarkType;

--- a/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
@@ -15,8 +15,10 @@ export interface IBookmarksManager {
 	addBookmark(resource: URI, scope: BookmarkType): void;
 	getBookmarkType(resource: URI): BookmarkType;
 	toggleBookmarkType(resource: URI): BookmarkType;
+	sortBookmarks(sortType: SortType): void;
 
 	onAddedBookmark: Event<{ uri: URI, bookmarkType: BookmarkType, prevBookmarkType: BookmarkType }>;
+	onDidSortBookmark: Event<SortType>;
 }
 
 export const IBookmarksManager = createDecorator<IBookmarksManager>('bookmarksManager');
@@ -25,6 +27,11 @@ export const enum BookmarkType {
 	NONE,
 	WORKSPACE,
 	GLOBAL
+}
+
+export const enum SortType {
+	NAME,
+	DATE
 }
 
 export function bookmarkClass(type: BookmarkType): string {


### PR DESCRIPTION
Implemented sort by name and sort by date for the bookmarks panel.

Sort by date:
- rather than keeping track of the actual times when bookmarks are set, always add them to the front of their sets so that they are sorted by date, left to right. 
This way, sorting by date does not incur an extra cost (apart from setting the list in the tree and re-rendering it).
When the array is sorted by date, new bookmarks are rendered at index 0.

Sort by name: 
- if the array is sorted by name, find the index where a new bookmarks should be inserted through a binary search.