### PR TITLE
Ready - Avoid too many calls to basename() and dirname() by storing these as properties of the bookmark class

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -381,7 +381,7 @@ export class BookmarksView extends ViewPane {
 			const compareNames = bookmark1.element.getName().localeCompare(bookmark2.element.getName());
 
 			// If directories have the same name, compare them by their full path
-			return compareNames ? compareNames : bookmark1.element.getParent().localeCompare(bookmark2.element.getParent());
+			return compareNames || bookmark1.element.getParent().localeCompare(bookmark2.element.getParent());
 		});
 	}
 


### PR DESCRIPTION
This way, when a refresh() needs to happen and bookmarks are stored again, we do just O(n) work to create the bookmarks objects then, in the sorting, each call to getName() and getParent() is just retrieving a property rather than making another extra call to basename() or dirname().

These calls are only done in the constructor.