### PR TITLE
Ready  - Handle active file not being a child of the current root

### DIFF
--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -49,7 +49,7 @@ export interface IExplorerService {
 	refresh(): Promise<void>;
 	setToCopy(stats: ExplorerItem[], cut: boolean): Promise<void>;
 	isCut(stat: ExplorerItem): boolean;
-	setRoot(resource: URI): void;
+	setRoot(resource: URI, selectResource?: URI): void;
 	onDidChangeRoot: Event<void>;
 
 	/**

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -53,7 +53,7 @@ import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/uriIdentity';
-import { dirname, basename } from 'vs/base/common/resources';
+import { dirname, basename, isEqualOrParent } from 'vs/base/common/resources';
 import { Codicon } from 'vs/base/common/codicons';
 import 'vs/css!./media/treeNavigation';
 import { IBookmarksManager } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
@@ -337,14 +337,14 @@ export class ExplorerView extends ViewPane {
 		// When the explorer viewer is loaded, listen to changes to the editor input
 		this._register(this.editorService.onDidActiveEditorChange(() => {
 			const resource = this.getActiveFile();
+			const root = (this.tree.getInput() as ExplorerItem).resource;
 			if (!resource) {
 				return;
 			}
-
-			if (this.isChildOfCurrentRoot(resource)) {
-				this.expandAncestorsToRoot(resource).then(() => this.selectActiveFile(false, true));
-			} else {
+			if (!root || !isEqualOrParent(resource, root)) {
 				this.explorerService.setRoot(dirname(resource), resource);
+			} else {
+				this.expandAncestorsAndSelect(resource);
 			}
 		}));
 
@@ -811,31 +811,13 @@ export class ExplorerView extends ViewPane {
 		return withNullAsUndefined(toResource(input, { supportSideBySide: SideBySideEditor.PRIMARY }));
 	}
 
-	private isChildOfCurrentRoot(resource: URI): boolean {
-		const currentRoot = this.tree.getInput() as ExplorerItem;
-		if (!currentRoot) {
-			return false;
-		}
-		const currentRootResource = currentRoot.resource.toString();
-
-		let remainingPath: URI = resource;
-		while (!this.isWorkspaceRoot(remainingPath)) {
-			if (remainingPath.toString() === currentRootResource) {
-				return true;
-			}
-
-			remainingPath = dirname(remainingPath);
-		}
-
-		return remainingPath.toString() === currentRootResource;
-	}
-
-	private async expandAncestorsToRoot(resource: URI): Promise<void> {
+	private async expandAncestorsAndSelect(resource: URI): Promise<void> {
 		const ancestors: URI[] = [];
 		const treeInput = this.tree.getInput() as ExplorerItem;
+		const rootResource = treeInput.resource.toString();
 		let findAncestor: URI = resource;
 
-		while (findAncestor.toString() !== treeInput.resource.toString()) {
+		while (findAncestor.toString() !== rootResource) {
 			ancestors.push(findAncestor);
 			findAncestor = dirname(findAncestor);
 		}
@@ -849,6 +831,11 @@ export class ExplorerView extends ViewPane {
 				await this.tree.expand(expandNext);
 				toExpand = expandNext;
 			}
+		}
+
+		const currentRoot = this.tree.getInput() as ExplorerItem;
+		if (rootResource === currentRoot.resource.toString()) {
+			this.selectActiveFile(/*deselect*/ false, /*reveal*/ true);
 		}
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -827,10 +827,12 @@ export class ExplorerView extends ViewPane {
 		let toExpand = treeInput;
 		for (let i = 0; i < ancestors.length; i++) {
 			const expandNext = toExpand.getChild(basename(ancestors[i]));
-			if (expandNext) {
-				await this.tree.expand(expandNext);
-				toExpand = expandNext;
+			if (!expandNext) {
+				return;
 			}
+
+			await this.tree.expand(expandNext);
+			toExpand = expandNext;
 
 			const currentRoot = this.tree.getInput() as ExplorerItem;
 			if (rootResource !== currentRoot.resource.toString()) {

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -815,11 +815,11 @@ export class ExplorerView extends ViewPane {
 		const ancestors: URI[] = [];
 		const treeInput = this.tree.getInput() as ExplorerItem;
 		const rootResource = treeInput.resource.toString();
-		let findAncestor: URI = resource;
+		let ancestor: URI = resource;
 
-		while (findAncestor.toString() !== rootResource) {
-			ancestors.push(findAncestor);
-			findAncestor = dirname(findAncestor);
+		while (ancestor.toString() !== rootResource) {
+			ancestors.push(ancestor);
+			ancestor = dirname(ancestor);
 		}
 
 		ancestors.reverse();
@@ -840,7 +840,7 @@ export class ExplorerView extends ViewPane {
 
 		const currentRoot = this.tree.getInput() as ExplorerItem;
 		if (rootResource === currentRoot.resource.toString()) {
-			this.selectActiveFile(/*deselect*/ false, /*reveal*/ true);
+			this.selectResource(resource);
 		}
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -336,7 +336,29 @@ export class ExplorerView extends ViewPane {
 
 		// When the explorer viewer is loaded, listen to changes to the editor input
 		this._register(this.editorService.onDidActiveEditorChange(() => {
-			this.selectActiveFile();
+			const resource = this.getActiveFile();
+			if (!resource) {
+				return;
+			}
+
+			if (this.isChildOfCurrentRoot(resource)) {
+				this.expandAncestorsToRoot(resource).then(() => this.selectActiveFile(false, true));
+			} else {
+				this.explorerService.setRoot(dirname(resource));
+			}
+		}));
+
+		this._register(this.explorerService.onDidChangeRoot(() => {
+			const root = this.tree.getInput() as ExplorerItem;
+			if (root) {
+				const activeFile = this.getActiveFile();
+				const treeSelection = this.tree.getSelection();
+				const activeFileSelected = treeSelection.find(selection => selection.resource.toString() === activeFile?.toString());
+
+				if (activeFile && !activeFileSelected && this.isChildOfCurrentRoot(activeFile)) {
+					this.selectActiveFile();
+				}
+			}
 		}));
 
 		// Also handle configuration updates
@@ -800,6 +822,47 @@ export class ExplorerView extends ViewPane {
 
 		// check for files
 		return withNullAsUndefined(toResource(input, { supportSideBySide: SideBySideEditor.PRIMARY }));
+	}
+
+	private isChildOfCurrentRoot(resource: URI): boolean {
+		const currentRoot = this.tree.getInput() as ExplorerItem;
+		if (!currentRoot) {
+			return false;
+		}
+		const currentRootResource = currentRoot.resource.toString();
+
+		let remainingPath: URI = resource;
+		while (!this.isWorkspaceRoot(remainingPath)) {
+			if (remainingPath.toString() === currentRootResource) {
+				return true;
+			}
+
+			remainingPath = dirname(remainingPath);
+		}
+
+		return remainingPath.toString() === currentRootResource;
+	}
+
+	private async expandAncestorsToRoot(resource: URI): Promise<void> {
+		const ancestors: URI[] = [];
+		const treeInput = this.tree.getInput() as ExplorerItem;
+		let findAncestor: URI = resource;
+
+		while (findAncestor.toString() !== treeInput.resource.toString()) {
+			ancestors.push(findAncestor);
+			findAncestor = dirname(findAncestor);
+		}
+
+		ancestors.reverse();
+
+		let toExpand = treeInput;
+		for (let i = 0; i < ancestors.length; i++) {
+			const expandNext = toExpand.getChild(basename(ancestors[i]));
+			if (expandNext) {
+				await this.tree.expand(expandNext);
+				toExpand = expandNext;
+			}
+		}
 	}
 
 	public async selectResource(resource: URI | undefined, reveal = this.autoReveal, retry = 0): Promise<void> {

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -831,6 +831,11 @@ export class ExplorerView extends ViewPane {
 				await this.tree.expand(expandNext);
 				toExpand = expandNext;
 			}
+
+			const currentRoot = this.tree.getInput() as ExplorerItem;
+			if (rootResource !== currentRoot.resource.toString()) {
+				return;
+			}
 		}
 
 		const currentRoot = this.tree.getInput() as ExplorerItem;

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -344,20 +344,7 @@ export class ExplorerView extends ViewPane {
 			if (this.isChildOfCurrentRoot(resource)) {
 				this.expandAncestorsToRoot(resource).then(() => this.selectActiveFile(false, true));
 			} else {
-				this.explorerService.setRoot(dirname(resource));
-			}
-		}));
-
-		this._register(this.explorerService.onDidChangeRoot(() => {
-			const root = this.tree.getInput() as ExplorerItem;
-			if (root) {
-				const activeFile = this.getActiveFile();
-				const treeSelection = this.tree.getSelection();
-				const activeFileSelected = treeSelection.find(selection => selection.resource.toString() === activeFile?.toString());
-
-				if (activeFile && !activeFileSelected && this.isChildOfCurrentRoot(activeFile)) {
-					this.selectActiveFile();
-				}
+				this.explorerService.setRoot(dirname(resource), resource);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -74,9 +74,8 @@ export class ExplorerService implements IExplorerService {
 		}));
 		this.disposables.add(this.model.onDidChangeRoots(() => {
 			if (this.view) {
-				this.view.setTreeInput();
+				this.view.setTreeInput().then(() => this._onDidChangeRoot.fire());
 			}
-			this._onDidChangeRoot.fire();
 		}));
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -142,8 +142,13 @@ export class ExplorerService implements IExplorerService {
 		return !!this.cutItems && this.cutItems.indexOf(item) >= 0;
 	}
 
-	setRoot(resource: URI): void {
-		this.model.setRoot(resource, this.sortOrder);
+	setRoot(resource: URI, fileToSelect: URI | undefined = undefined): void {
+		this.model.setRoot(resource, this.sortOrder).then(() =>
+			this.view?.setTreeInput().then(() => {
+				if (fileToSelect) {
+					this.view?.selectResource(fileToSelect);
+				}
+			}));
 	}
 
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -145,7 +145,8 @@ export class ExplorerService implements IExplorerService {
 	setRoot(resource: URI, fileToSelect: URI | undefined = undefined): void {
 		this.model.setRoot(resource, this.sortOrder).then(() =>
 			this.view?.setTreeInput().then(() => {
-				if (fileToSelect) {
+				// There is a file to select and the root has not changed in the meantime
+				if (fileToSelect && resource.toString() === this.roots[0].resource.toString()) {
 					this.view?.selectResource(fileToSelect);
 				}
 			}));


### PR DESCRIPTION
If the active editor file is a child of the current root, then expand all its ancestors up to the root.
Otherwise, set its parent as the new root.

In either case, select the file in the tree.