### PR TITLE
Ready - Avoid expanding or collapsing directory when the bookmark icon is clicked

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -952,7 +952,7 @@ export interface IAbstractTreeOptionsUpdate extends ITreeRendererOptions {
 	readonly smoothScrolling?: boolean;
 	readonly horizontalScrolling?: boolean;
 	readonly expandOnlyOnDoubleClick?: boolean;
-	readonly bookmarksClasses?: string[];
+	readonly preserveCollapseStateOnTargets?: string[];
 }
 
 export interface IAbstractTreeOptions<T, TFilterData = void> extends IAbstractTreeOptionsUpdate, IListOptions<T> {
@@ -1116,7 +1116,7 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 			return super.onViewPointer(e);
 		}
 
-		if (this.wasBookmarkClicked(target)) {
+		if (!this.preserveCollapseState(target)) {
 			return super.onViewPointer(e);
 		}
 
@@ -1144,18 +1144,18 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 		super.onDoubleClick(e);
 	}
 
-	private wasBookmarkClicked(target: HTMLElement): boolean {
-		if (!this.tree.options.bookmarksClasses) {
-			return false;
+	private preserveCollapseState(target: HTMLElement): boolean {
+		if (!this.tree.options.preserveCollapseStateOnTargets) {
+			return true;
 		}
 
-		for (let bookmarkClassName of this.tree.options.bookmarksClasses) {
+		for (let bookmarkClassName of this.tree.options.preserveCollapseStateOnTargets) {
 			if (hasClass(target, bookmarkClassName)) {
-				return true;
+				return false;
 			}
 		}
 
-		return false;
+		return true;
 	}
 }
 

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -952,6 +952,7 @@ export interface IAbstractTreeOptionsUpdate extends ITreeRendererOptions {
 	readonly smoothScrolling?: boolean;
 	readonly horizontalScrolling?: boolean;
 	readonly expandOnlyOnDoubleClick?: boolean;
+	readonly bookmarksClasses?: string[];
 }
 
 export interface IAbstractTreeOptions<T, TFilterData = void> extends IAbstractTreeOptionsUpdate, IListOptions<T> {
@@ -1115,6 +1116,10 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 			return super.onViewPointer(e);
 		}
 
+		if (this.wasBookmarkClicked(target)) {
+			return super.onViewPointer(e);
+		}
+
 		if (node.collapsible) {
 			const model = ((this.tree as any).model as ITreeModel<T, TFilterData, TRef>); // internal
 			const location = model.getNodeLocation(node);
@@ -1137,6 +1142,20 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 		}
 
 		super.onDoubleClick(e);
+	}
+
+	private wasBookmarkClicked(target: HTMLElement): boolean {
+		if (!this.tree.options.bookmarksClasses) {
+			return false;
+		}
+
+		for (let bookmarkClassName of this.tree.options.bookmarksClasses) {
+			if (hasClass(target, bookmarkClassName)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -56,7 +56,7 @@ import { IUriIdentityService } from 'vs/workbench/services/uriIdentity/common/ur
 import { dirname, basename } from 'vs/base/common/resources';
 import { Codicon } from 'vs/base/common/codicons';
 import 'vs/css!./media/treeNavigation';
-import { IBookmarksManager } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
+import { IBookmarksManager, allBookmarksClasses } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 
 interface IExplorerViewColors extends IColorMapping {
 	listDropBackground?: ColorValue | undefined;
@@ -556,6 +556,8 @@ export class ExplorerView extends ViewPane {
 				}
 			}
 		}));
+
+		this.tree.updateOptions({ bookmarksClasses: allBookmarksClasses });
 
 		// save view state
 		this._register(this.storageService.onWillSaveState(() => {

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -557,7 +557,7 @@ export class ExplorerView extends ViewPane {
 			}
 		}));
 
-		this.tree.updateOptions({ bookmarksClasses: allBookmarksClasses });
+		this.tree.updateOptions({ preserveCollapseStateOnTargets: allBookmarksClasses });
 
 		// save view state
 		this._register(this.storageService.onWillSaveState(() => {

--- a/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
@@ -45,3 +45,5 @@ export function bookmarkClass(type: BookmarkType): string {
 
 	return 'bookmark-not-set';
 }
+
+export const allBookmarksClasses = [bookmarkClass(BookmarkType.NONE), bookmarkClass(BookmarkType.WORKSPACE), bookmarkClass(BookmarkType.GLOBAL)];


### PR DESCRIPTION
Use tree.updateOptions() to pass the names of the classes for the bookmarks icons without having to hard-code them or import anything from the contribution into the core component.