### PR TITLE
Ready - Add option to bookmark directories in the file tree context menu

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -22,7 +22,7 @@ import { Directory } from 'vs/workbench/contrib/scopeTree/browser/directoryViewe
 const addBookmark: ICommandHandler = (accessor: ServicesAccessor, scope: BookmarkType) => {
 	const bookmarksManager = accessor.get(IBookmarksManager);
 	const explorerService = accessor.get(IExplorerService);
-	const stats = explorerService.getContext(true);	// respectMultiSelection
+	const stats = explorerService.getContext(/*respectMultiSelection = */ true);
 
 	for (let stat of stats) {
 		if (stat.isDirectory) {


### PR DESCRIPTION
Add "Add global bookmark" and "Add workspace bookmark" options to the context menu in the main file tree.
This will allow the users to add a bookmark in two ways:
1. From this context menu
2. By clicking on the star icon next to each directory name. This also allows the user to toggle the scope of an existing bookmark.