### PR TITLE
Ready - Refactor the view of the bookmarks in the main file tree

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1285,14 +1285,7 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		const onDidChangeCollapseStateRelay = new Relay<ICollapseStateChangeEvent<T, TFilterData>>();
 		const onDidChangeActiveNodes = new Relay<ITreeNode<T, TFilterData>[]>();
 		const activeNodes = new EventCollection(onDidChangeActiveNodes.event);
-		this.renderers = renderers.map(r => {
-			if (r.templateId === 'file') {
-				return (new TreeRendererWithIndent<T, TFilterData, TRef, any>(r, () => this.model, onDidChangeCollapseStateRelay.event, activeNodes, _options));
-			}
-			else {
-				return (new TreeRenderer<T, TFilterData, TRef, any>(r, () => this.model, onDidChangeCollapseStateRelay.event, activeNodes, _options));
-			}
-		});
+		this.renderers = renderers.map(r => this.createTreeRenderer(r, onDidChangeCollapseStateRelay, activeNodes, _options));
 		for (let r of this.renderers) {
 			this.disposables.add(r);
 		}
@@ -1711,6 +1704,15 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		const recursive = e.browserEvent.altKey;
 
 		this.model.setCollapsed(location, undefined, recursive);
+	}
+
+	private createTreeRenderer(renderer: ITreeRenderer<T, TFilterData, any>, onDidChangeCollapseStateRelay: Relay<ICollapseStateChangeEvent<T, TFilterData>>, activeNodes: EventCollection<ITreeNode<T, TFilterData>>, options: IAbstractTreeOptions<T, TFilterData>) {
+		if (renderer.templateId === 'file') {
+			return new TreeRendererWithIndent<T, TFilterData, TRef, any>(renderer, () => this.model, onDidChangeCollapseStateRelay.event, activeNodes, options);
+		}
+		else {
+			return new TreeRenderer<T, TFilterData, TRef, any>(renderer, () => this.model, onDidChangeCollapseStateRelay.event, activeNodes, options);
+		}
 	}
 
 	protected abstract createModel(user: string, view: ISpliceable<ITreeNode<T, TFilterData>>, options: IAbstractTreeOptions<T, TFilterData>): ITreeModel<T, TFilterData, TRef>;

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -272,7 +272,7 @@ class EventCollection<T> implements Collection<T> {
 
 class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer<ITreeNode<T, TFilterData>, ITreeListTemplateData<TTemplateData>> {
 
-	private static readonly DefaultIndent = 8;
+	protected static readonly DefaultIndent = 8;
 
 	readonly templateId: string;
 	private renderedElements = new Map<T, ITreeNode<T, TFilterData>>();
@@ -348,7 +348,7 @@ class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer
 		}
 
 		const indent = TreeRenderer.DefaultIndent + (node.depth - 1) * this.indent;
-		templateData.twistie.style.paddingLeft = `${indent - 8}px`;
+		templateData.twistie.style.paddingLeft = `${indent}px`;
 		templateData.indent.style.width = `${indent + this.indent - 16}px`;
 
 		this.renderTwistie(node, templateData);
@@ -458,7 +458,6 @@ class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer
 			node = parent;
 		}
 
-		templateData.indent.style.paddingLeft = '8px';
 		templateData.indentGuidesDisposable = disposableStore;
 	}
 
@@ -505,6 +504,16 @@ class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer
 		this.renderedElements.clear();
 		this.indentGuidesDisposable.dispose();
 		dispose(this.disposables);
+	}
+}
+
+class TreeRendererWithIndent<T, TFilterData, TRef, TTemplateData> extends TreeRenderer<T, TFilterData, TRef, TTemplateData>{
+	renderElement(node: ITreeNode<T, TFilterData>, index: number, templateData: ITreeListTemplateData<TTemplateData>, height: number | undefined): void {
+		super.renderElement(node, index, templateData, height);
+
+		const paddingLeft = parseInt(templateData.twistie.style.paddingLeft);
+		templateData.twistie.style.paddingLeft = `${paddingLeft - TreeRenderer.DefaultIndent}px`;
+		templateData.indent.style.paddingLeft = `${TreeRenderer.DefaultIndent}px`;
 	}
 }
 
@@ -1276,7 +1285,14 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		const onDidChangeCollapseStateRelay = new Relay<ICollapseStateChangeEvent<T, TFilterData>>();
 		const onDidChangeActiveNodes = new Relay<ITreeNode<T, TFilterData>[]>();
 		const activeNodes = new EventCollection(onDidChangeActiveNodes.event);
-		this.renderers = renderers.map(r => new TreeRenderer<T, TFilterData, TRef, any>(r, () => this.model, onDidChangeCollapseStateRelay.event, activeNodes, _options));
+		this.renderers = renderers.map(r => {
+			if (r.templateId === 'file') {
+				return (new TreeRendererWithIndent<T, TFilterData, TRef, any>(r, () => this.model, onDidChangeCollapseStateRelay.event, activeNodes, _options));
+			}
+			else {
+				return (new TreeRenderer<T, TFilterData, TRef, any>(r, () => this.model, onDidChangeCollapseStateRelay.event, activeNodes, _options));
+			}
+		});
 		for (let r of this.renderers) {
 			this.disposables.add(r);
 		}

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -348,7 +348,7 @@ class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer
 		}
 
 		const indent = TreeRenderer.DefaultIndent + (node.depth - 1) * this.indent;
-		templateData.twistie.style.paddingLeft = `${indent}px`;
+		templateData.twistie.style.paddingLeft = `${indent - 8}px`;
 		templateData.indent.style.width = `${indent + this.indent - 16}px`;
 
 		this.renderTwistie(node, templateData);
@@ -458,6 +458,7 @@ class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListRenderer
 			node = parent;
 		}
 
+		templateData.indent.style.paddingLeft = '8px';
 		templateData.indentGuidesDisposable = disposableStore;
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -363,18 +363,28 @@ export class ExplorerView extends ViewPane {
 		});
 
 		this._register(this.tree.onMouseOver(e => {
-			const icon = document.getElementById('iconContainer_' + e.element?.resource.toString());
+			const resource = e.element?.resource.toString();
+			const icon = document.getElementById('iconContainer_' + resource);
+			const bookmarkIconContainer = document.getElementById('bookmarkIconContainer_' + resource);
 
-			if (icon !== null) {
+			if (icon) {
 				icon.style.visibility = 'visible';
+			}
+			if (bookmarkIconContainer) {
+				bookmarkIconContainer.style.visibility = 'visible';
 			}
 		}));
 
 		this._register(this.tree.onMouseOut(e => {
-			const icon = document.getElementById('iconContainer_' + e.element?.resource.toString());
+			const resource = e.element?.resource.toString();
+			const icon = document.getElementById('iconContainer_' + resource);
+			const bookmarkIconContainer = document.getElementById('bookmarkIconContainer_' + resource);
 
-			if (icon !== null) {
+			if (icon) {
 				icon.style.visibility = 'hidden';
+			}
+			if (bookmarkIconContainer && e.element && !this.bookmarksManager.getBookmarkType(e.element.resource)) {
+				bookmarkIconContainer.style.visibility = 'hidden';
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
@@ -265,11 +265,18 @@ class BookmarkIconRenderer implements IDisposable {
 	constructor(stat: ExplorerItem, bookmarkManager: IBookmarksManager) {
 		this._iconContainer = document.createElement('img');
 		this._iconContainer.id = 'bookmarkIconContainer_' + stat.resource.toString();
-		this._iconContainer.className = bookmarkClass(bookmarkManager.getBookmarkType(stat.resource));
 		this._iconContainer.onclick = () => {
 			const newType = bookmarkManager.toggleBookmarkType(stat.resource);
 			this._iconContainer.className = bookmarkClass(newType);
 		};
+
+		const bookmarkType = bookmarkManager.getBookmarkType(stat.resource);
+		this._iconContainer.className = bookmarkClass(bookmarkType);
+		if (!bookmarkType) {
+			this._iconContainer.style.visibility = 'hidden';
+		}
+
+		this._iconContainer.style.paddingRight = '0px';
 	}
 
 	get iconContainer(): HTMLElement {

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
@@ -275,8 +275,6 @@ class BookmarkIconRenderer implements IDisposable {
 		if (!bookmarkType) {
 			this._iconContainer.style.visibility = 'hidden';
 		}
-
-		this._iconContainer.style.paddingRight = '0px';
 	}
 
 	get iconContainer(): HTMLElement {

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
@@ -421,25 +421,26 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 			}
 		});
 
+		const focusIcon = new FocusIconRenderer(stat);
+		const contentContainer = this.getContentsContainerElement(templateData.label.element);
+		const rowContainer = this.getRowContainerElement(contentContainer);
+		rowContainer.insertBefore(focusIcon.iconContainer, rowContainer.firstChild);
+
 		if (stat.isDirectory) {
-			const focusIcon = new FocusIconRenderer(stat);
 			focusIcon.iconContainer.onclick = () => this.explorerService.setRoot(stat.resource);
-
-			templateData.label.element.style.float = 'left';
-			templateData.label.element.appendChild(focusIcon.iconContainer);
-
-			disposables.add(focusIcon);
 
 			if (this.bookmarksManager) {
 				const bookmarkIcon = new BookmarkIconRenderer(stat, this.bookmarksManager);
-				const contentContainer = this.getContentsContainerElement(templateData.label.element);
-				const rowContainer = this.getRowContainerElement(contentContainer);
+				bookmarkIcon.iconContainer.style.paddingRight = '10px';
 
+				templateData.label.element.appendChild(bookmarkIcon.iconContainer);
 				disposables.add(bookmarkIcon);
-				rowContainer.insertBefore(bookmarkIcon.iconContainer, contentContainer);
 			}
+		} else {
+			focusIcon.iconContainer.style.opacity = '0';
 		}
 
+		disposables.add(focusIcon);
 		disposables.add(prevDisposable);
 		return disposables;
 	}

--- a/src/vs/workbench/contrib/scopeTree/browser/media/scopeTreeFileIcon.css
+++ b/src/vs/workbench/contrib/scopeTree/browser/media/scopeTreeFileIcon.css
@@ -7,7 +7,6 @@
 	content: url('scope.svg');
 	float: left;
 	align-self: center;
+	width: 16px;
 	visibility: hidden;
-	display: flex;
-	padding-left: 10px;
 }


### PR DESCRIPTION
The scope icon is now rendered on the left, next to the name of the directory.
The bookmark icon is now rendered on the far right and is only visible on mouse hover (if a bookmark is not set, to indicate that the star action can be used to add one).

The indent guides need to be aligned in the abstractTree file and I don't think there is any simple way to avoid modifying that.