### PR TITLE
Ready - Avoid triggering _onDidChangeRoot when a file has to be selected in setRoot()

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerModel.ts
@@ -8,15 +8,15 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { coalesce } from 'vs/base/common/arrays';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
-import { Emitter, Event } from 'vs/base/common/event';
 import { SortOrder } from 'vs/workbench/contrib/files/common/files';
 import { ExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
+import { Emitter, Event } from 'vs/base/common/event';
 
 export class ExplorerModel implements IDisposable {
 
 	private _roots!: ExplorerItem[];
 	private _listener: IDisposable;
-	private readonly _onDidChangeRoots = new Emitter<void>();
+	private readonly _onDidChangeWorkspaceFolders = new Emitter<void>();
 
 	constructor(
 		private readonly contextService: IWorkspaceContextService,
@@ -28,7 +28,7 @@ export class ExplorerModel implements IDisposable {
 
 		this._listener = this.contextService.onDidChangeWorkspaceFolders(() => {
 			setRoots();
-			this._onDidChangeRoots.fire();
+			this._onDidChangeWorkspaceFolders.fire();
 		});
 	}
 
@@ -36,11 +36,11 @@ export class ExplorerModel implements IDisposable {
 		return this._roots;
 	}
 
-	get onDidChangeRoots(): Event<void> {
-		return this._onDidChangeRoots.event;
+	get onDidChangeWorkspaceFolders(): Event<void> {
+		return this._onDidChangeWorkspaceFolders.event;
 	}
 
-	async setRoot(resource: URI, sortOrder: SortOrder, triggerRootsChanged?: boolean): Promise<void> {
+	async setRoot(resource: URI, sortOrder: SortOrder): Promise<void> {
 		const root = new ExplorerItem(resource, this.fileService, undefined);
 
 		const children = await root.fetchChildren(sortOrder);
@@ -49,10 +49,6 @@ export class ExplorerModel implements IDisposable {
 		});
 
 		this._roots = [root];
-
-		if (triggerRootsChanged) {
-			this._onDidChangeRoots.fire();
-		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/scopeTree/common/explorerModel.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerModel.ts
@@ -40,17 +40,19 @@ export class ExplorerModel implements IDisposable {
 		return this._onDidChangeRoots.event;
 	}
 
-	async setRoot(resource: URI, sortOrder: SortOrder): Promise<void> {
+	async setRoot(resource: URI, sortOrder: SortOrder, triggerRootsChanged?: boolean): Promise<void> {
 		const root = new ExplorerItem(resource, this.fileService, undefined);
 
 		const children = await root.fetchChildren(sortOrder);
-
 		children.forEach(child => {
 			root.addChild(child);
 		});
 
 		this._roots = [root];
-		this._onDidChangeRoots.fire();
+
+		if (triggerRootsChanged) {
+			this._onDidChangeRoots.fire();
+		}
 	}
 
 	/**

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -146,7 +146,7 @@ export class ExplorerService implements IExplorerService {
 		this.model.setRoot(resource, this.sortOrder).then(() =>
 			this.view?.setTreeInput().then(() => {
 				// There is a file to select and the root has not changed in the meantime
-				if (resource.toString() === this.roots[0].resource.toString()) {
+				if (fileToSelect && resource.toString() === this.roots[0].resource.toString()) {
 					this.view?.selectResource(fileToSelect);
 				}
 				this._onDidChangeRoot.fire();

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -143,13 +143,19 @@ export class ExplorerService implements IExplorerService {
 	}
 
 	setRoot(resource: URI, fileToSelect: URI | undefined = undefined): void {
-		this.model.setRoot(resource, this.sortOrder).then(() =>
-			this.view?.setTreeInput().then(() => {
-				// There is a file to select and the root has not changed in the meantime
-				if (fileToSelect && resource.toString() === this.roots[0].resource.toString()) {
-					this.view?.selectResource(fileToSelect);
-				}
-			}));
+		// If we need to select a resource, we want to set the tree input 'manually', so avoid triggering model.onDidChangeRoots
+		if (!fileToSelect) {
+			this.model.setRoot(resource, this.sortOrder, true);
+		}
+		else {
+			this.model.setRoot(resource, this.sortOrder, false).then(() =>
+				this.view?.setTreeInput().then(() => {
+					// There is a file to select and the root has not changed in the meantime
+					if (resource.toString() === this.roots[0].resource.toString()) {
+						this.view?.selectResource(fileToSelect);
+					}
+				}));
+		}
 	}
 
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -72,7 +72,7 @@ export class ExplorerService implements IExplorerService {
 				}
 			}
 		}));
-		this.disposables.add(this.model.onDidChangeRoots(() => {
+		this.disposables.add(this.model.onDidChangeWorkspaceFolders(() => {
 			if (this.view) {
 				this.view.setTreeInput().then(() => this._onDidChangeRoot.fire());
 			}
@@ -143,19 +143,14 @@ export class ExplorerService implements IExplorerService {
 	}
 
 	setRoot(resource: URI, fileToSelect: URI | undefined = undefined): void {
-		// If we need to select a resource, we want to set the tree input 'manually', so avoid triggering model.onDidChangeRoots
-		if (!fileToSelect) {
-			this.model.setRoot(resource, this.sortOrder, true);
-		}
-		else {
-			this.model.setRoot(resource, this.sortOrder, false).then(() =>
-				this.view?.setTreeInput().then(() => {
-					// There is a file to select and the root has not changed in the meantime
-					if (resource.toString() === this.roots[0].resource.toString()) {
-						this.view?.selectResource(fileToSelect);
-					}
-				}));
-		}
+		this.model.setRoot(resource, this.sortOrder).then(() =>
+			this.view?.setTreeInput().then(() => {
+				// There is a file to select and the root has not changed in the meantime
+				if (resource.toString() === this.roots[0].resource.toString()) {
+					this.view?.selectResource(fileToSelect);
+				}
+				this._onDidChangeRoot.fire();
+			}));
 	}
 
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {


### PR DESCRIPTION
When setRoot() is called and a file has to be selected, the root of the view is set in setRoot() so _onDidChangeRoot should not be triggered because this would call view.setTreeInput() again.