### PR TITLE
Ready - Handle selected bookmark not being a child of the current root

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -17,6 +17,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { getMultiSelectedResources } from 'vs/workbench/contrib/files/browser/files';
 import { AbstractTree } from 'vs/base/browser/ui/tree/abstractTree';
 import { Directory } from 'vs/workbench/contrib/scopeTree/browser/directoryViewer';
+import { isEqualOrParent } from 'vs/base/common/resources';
 
 // Handlers implementations for context menu actions
 const addBookmark: ICommandHandler = (accessor: ServicesAccessor, scope: BookmarkType) => {
@@ -77,7 +78,16 @@ const sortBookmarksByDate: ICommandHandler = (accessor: ServicesAccessor) => {
 
 const displayBookmarkInFileTree: ICommandHandler = (accessor: ServicesAccessor, element: Directory | BookmarkHeader) => {
 	if (element && element instanceof Directory) {
-		accessor.get(IExplorerService).select(element.resource);
+		const explorerService = accessor.get(IExplorerService);
+		const rootResource = explorerService.roots[0].resource;
+		const selectedResource = element.resource;
+
+		const isChildOfCurrentRoot = isEqualOrParent(selectedResource, rootResource);
+		if (isChildOfCurrentRoot) {
+			explorerService.select(selectedResource);
+		} else {
+			explorerService.setRoot(selectedResource);
+		}
 	}
 };
 


### PR DESCRIPTION
When the 'Show in file tree' action is selected in the bookmarks context menu there are two possibilities:
<li> If the directory exists under the current root, select it in the file tree</li>
<li> Otherwise, set the directory as root in the main file tree</li>