### PR TITLE
Needs changes - Align items in the main file tree and in the breadcrumb

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -513,7 +513,7 @@ class TreeRendererWithIndent<T, TFilterData, TRef, TTemplateData> extends TreeRe
 
 		const paddingLeft = parseInt(templateData.twistie.style.paddingLeft);
 		templateData.twistie.style.paddingLeft = `${paddingLeft - TreeRenderer.DefaultIndent}px`;
-		templateData.indent.style.paddingLeft = `${TreeRenderer.DefaultIndent}px`;
+		templateData.indent.style.paddingLeft = `${TreeRenderer.DefaultIndent * 2}px`;
 	}
 }
 

--- a/src/vs/workbench/contrib/scopeTree/browser/breadcrumbObserver.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/breadcrumbObserver.ts
@@ -50,6 +50,7 @@ export class BreadcrumbObserver implements IBreadcrumbObserver {
 		const iconContainer = document.createElement('img');
 		iconContainer.className = 'scope-tree-focus-icon';
 		iconContainer.id = 'breadcrumbFocusIconContainer_' + resource.toString();
+		iconContainer.style.paddingLeft = '5px';	// Leave some space between the dir name and icon in the breadcrumb
 
 		const previousIcon = templateData.element.lastChild;
 		if (previousIcon && (<HTMLElement>previousIcon).className === 'scope-tree-focus-icon') {

--- a/src/vs/workbench/contrib/scopeTree/browser/breadcrumbObserver.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/breadcrumbObserver.ts
@@ -48,12 +48,11 @@ export class BreadcrumbObserver implements IBreadcrumbObserver {
 		templateData.element.style.float = '';
 
 		const iconContainer = document.createElement('img');
-		iconContainer.className = 'scope-tree-focus-icon';
+		iconContainer.className = 'scope-tree-focus-icon-breadcrumb-aligned';
 		iconContainer.id = 'breadcrumbFocusIconContainer_' + resource.toString();
-		iconContainer.style.paddingLeft = '5px';	// Leave some space between the dir name and icon in the breadcrumb
 
 		const previousIcon = templateData.element.lastChild;
-		if (previousIcon && (<HTMLElement>previousIcon).className === 'scope-tree-focus-icon') {
+		if (previousIcon && (<HTMLElement>previousIcon).className === 'scope-tree-focus-icon-breadcrumb-aligned') {
 			templateData.element.removeChild(previousIcon);
 		}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
@@ -437,7 +437,6 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 
 			if (this.bookmarksManager) {
 				const bookmarkIcon = new BookmarkIconRenderer(stat, this.bookmarksManager);
-
 				templateData.label.element.appendChild(bookmarkIcon.iconContainer);
 				disposables.add(bookmarkIcon);
 			}

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
@@ -246,9 +246,8 @@ class FocusIconRenderer implements IDisposable {
 
 	constructor(private stat: ExplorerItem) {
 		this._iconContainer = document.createElement('img');
-		DOM.addClass(this._iconContainer, 'scope-tree-focus-icon');
+		DOM.addClass(this._iconContainer, 'scope-tree-focus-icon-file-tree-aligned');
 		this._iconContainer.id = 'iconContainer_' + this.stat.resource.toString();
-		this._iconContainer.style.paddingLeft = '8px';	// The row is moved to the left in renderTemplate(), so the focus icon needs some extra padding
 	}
 
 	get iconContainer(): HTMLElement {

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
@@ -248,6 +248,7 @@ class FocusIconRenderer implements IDisposable {
 		this._iconContainer = document.createElement('img');
 		DOM.addClass(this._iconContainer, 'scope-tree-focus-icon');
 		this._iconContainer.id = 'iconContainer_' + this.stat.resource.toString();
+		this._iconContainer.style.paddingLeft = '8px';	// The row is moved to the left in renderTemplate(), so the focus icon needs some extra padding
 	}
 
 	get iconContainer(): HTMLElement {
@@ -265,6 +266,7 @@ class BookmarkIconRenderer implements IDisposable {
 	constructor(stat: ExplorerItem, bookmarkManager: IBookmarksManager) {
 		this._iconContainer = document.createElement('img');
 		this._iconContainer.id = 'bookmarkIconContainer_' + stat.resource.toString();
+		this._iconContainer.style.paddingRight = '0px';	// By default bookmarks leave some space between the icon and the directory name (in panels)
 		this._iconContainer.onclick = () => {
 			const newType = bookmarkManager.toggleBookmarkType(stat.resource);
 			this._iconContainer.className = bookmarkClass(newType);
@@ -329,8 +331,9 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 
 	renderTemplate(container: HTMLElement): IFileTemplateData {
 		const elementDisposable = Disposable.None;
+		const rowContainer = this.getRowContainerElement(container);
 		const label = this.labels.create(container, { supportHighlights: true });
-
+		rowContainer.style.left = '-10px';	// Move the whole row to the left so that bookmarks are not covered by the scrollbar
 		return { elementDisposable, label, container };
 	}
 
@@ -340,7 +343,6 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 		const editableData = this.explorerService.getEditableData(stat);
 
 		DOM.removeClass(templateData.label.element, 'compressed');
-
 		// File Label
 		if (!editableData) {
 			templateData.label.element.style.display = 'flex';
@@ -436,7 +438,6 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 
 			if (this.bookmarksManager) {
 				const bookmarkIcon = new BookmarkIconRenderer(stat, this.bookmarksManager);
-				bookmarkIcon.iconContainer.style.paddingRight = '10px';
 
 				templateData.label.element.appendChild(bookmarkIcon.iconContainer);
 				disposables.add(bookmarkIcon);

--- a/src/vs/workbench/contrib/scopeTree/browser/media/scopeTreeFileIcon.css
+++ b/src/vs/workbench/contrib/scopeTree/browser/media/scopeTreeFileIcon.css
@@ -10,3 +10,21 @@
 	width: 16px;
 	visibility: hidden;
 }
+
+.scope-tree-focus-icon-file-tree-aligned {
+	content: url('scope.svg');
+	float: left;
+	align-self: center;
+	width: 16px;
+	visibility: hidden;
+	padding-left: 8px; /* The row is moved to the left in renderTemplate(), so the focus icon needs some extra padding */
+}
+
+.scope-tree-focus-icon-breadcrumb-aligned {
+	content: url('scope.svg');
+	float: left;
+	align-self: center;
+	width: 16px;
+	visibility: hidden;
+	padding-left: 5px; /* Leave some space between the dir name and icon in the breadcrumb */
+}


### PR DESCRIPTION
Bookmarks need some padding to the right to ensure they are not covered by the scrollbar. This padding cannot be added directly to the bookmarks because there might be some additional decorations added by VSCode, and in that case the padding will be added with respect to those, which would mean a lot of empty space per row.

We can move the whole row to the left, then align the focus icon and there will be no additional padding required. This way we can be sure our additional icons do not affect the existing ones.