### PR TITLE
Ready - Synchronize changes to bookmarks across all panels

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -4,12 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ICommandHandler } from 'vs/platform/commands/common/commands';
-import { IBookmarksManager, BookmarkType, bookmarkClass, SortType } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
+import { IBookmarksManager, BookmarkType, SortType } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 import { MenuRegistry, MenuId } from 'vs/platform/actions/common/actions';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { BookmarkHeader } from 'vs/workbench/contrib/scopeTree/browser/bookmarksView';
 import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
-import { URI } from 'vs/base/common/uri';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { IListService } from 'vs/platform/list/browser/listService';
@@ -27,7 +26,6 @@ const addBookmark: ICommandHandler = (accessor: ServicesAccessor, scope: Bookmar
 	for (let stat of stats) {
 		if (stat.isDirectory) {
 			bookmarksManager.addBookmark(stat.resource, scope);
-			toggleIconIfVisible(stat.resource, scope);
 		}
 	}
 };
@@ -81,18 +79,10 @@ const displayBookmarkInFileTree: ICommandHandler = (accessor: ServicesAccessor, 
 	}
 };
 
-const toggleIconIfVisible = (resource: URI, scope: BookmarkType) => {
-	const bookmarkIcon = document.getElementById('bookmarkIconContainer_' + resource.toString());
-	if (bookmarkIcon) {
-		bookmarkIcon.className = bookmarkClass(scope);
-	}
-};
-
 const handleBookmarksChange = (accessor: ServicesAccessor, element: Directory, newScope: BookmarkType) => {
 	const bookmarksManager = accessor.get(IBookmarksManager);
 	const resource = element.resource;
 	bookmarksManager.addBookmark(resource, newScope);
-	toggleIconIfVisible(resource, newScope);
 };
 
 // Bookmarks panel context menu

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
@@ -65,7 +65,6 @@ export class BookmarksManager implements IBookmarksManager {
 			}
 		}
 
-		this.changeBookmarkIfVisible(resource, scope);
 		this._onBookmarksChanged.fire({ uri: resource, bookmarkType: scope, prevBookmarkType: prevScope });
 	}
 
@@ -124,15 +123,8 @@ export class BookmarksManager implements IBookmarksManager {
 		this.storageService.store(BookmarksManager.GLOBAL_BOOKMARKS_STORAGE_KEY, JSON.stringify(Array.from(this.globalBookmarks)), StorageScope.GLOBAL);
 	}
 
-	private changeBookmarkIfVisible(resource: URI, scope: BookmarkType): void {
-		const bookmarkIconInFileTree = document.getElementById('bookmarkIconContainer_' + resource.toString());
-		const bookmarkIconInRecentDirs = document.getElementById('bookmarkIconRecentDirectoryContainer_' + resource.toString());
-
-		this.changeTypeAndDisplay(bookmarkIconInFileTree, scope);
-		this.changeTypeAndDisplay(bookmarkIconInRecentDirs, scope);
-	}
-
-	private changeTypeAndDisplay(element: HTMLElement | null, scope: BookmarkType): void {
+	public changeTypeAndDisplay(bookmarkId: string, scope: BookmarkType): void {
+		const element = document.getElementById(bookmarkId);
 		if (!element) {
 			return;
 		}

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
@@ -5,7 +5,7 @@
 
 import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 import { URI } from 'vs/base/common/uri';
-import { IBookmarksManager, BookmarkType, SortType } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
+import { IBookmarksManager, BookmarkType, SortType, bookmarkClass } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 import { Emitter } from 'vs/base/common/event';
 
 export class BookmarksManager implements IBookmarksManager {
@@ -65,6 +65,7 @@ export class BookmarksManager implements IBookmarksManager {
 			}
 		}
 
+		this.changeBookmarkIfVisible(resource, scope);
 		this._onBookmarksChanged.fire({ uri: resource, bookmarkType: scope, prevBookmarkType: prevScope });
 	}
 
@@ -121,5 +122,27 @@ export class BookmarksManager implements IBookmarksManager {
 
 	private saveGlobalBookmarks(): void {
 		this.storageService.store(BookmarksManager.GLOBAL_BOOKMARKS_STORAGE_KEY, JSON.stringify(Array.from(this.globalBookmarks)), StorageScope.GLOBAL);
+	}
+
+	private changeBookmarkIfVisible(resource: URI, scope: BookmarkType): void {
+		const bookmarkIconInFileTree = document.getElementById('bookmarkIconContainer_' + resource.toString());
+		const bookmarkIconInRecentDirs = document.getElementById('bookmarkIconRecentDirectoryContainer_' + resource.toString());
+
+		this.changeTypeAndDisplay(bookmarkIconInFileTree, scope);
+		this.changeTypeAndDisplay(bookmarkIconInRecentDirs, scope);
+	}
+
+	private changeTypeAndDisplay(element: HTMLElement | null, scope: BookmarkType): void {
+		if (!element) {
+			return;
+		}
+
+		if (scope === BookmarkType.NONE) {
+			element.style.visibility = 'hidden';
+		} else {
+			element.style.visibility = 'visible';
+		}
+
+		element.className = bookmarkClass(scope);
 	}
 }

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -363,13 +363,14 @@ export class ExplorerView extends ViewPane {
 			}
 		}));
 
-		this.onDidChangeExpansionState(e => {
-			if (e) {
+		this._register(this.onDidChangeExpansionState(async visible => {
+			if (visible) {
 				DOM.show(breadcrumbBackground);
+				await this.setTreeInput();
 			} else {
 				DOM.hide(breadcrumbBackground);
 			}
-		});
+		}));
 
 		this._register(this.tree.onMouseOver(e => {
 			const resource = e.element?.resource.toString();
@@ -395,6 +396,14 @@ export class ExplorerView extends ViewPane {
 			if (bookmarkIconContainer && e.element && !this.bookmarksManager.getBookmarkType(e.element.resource)) {
 				bookmarkIconContainer.style.visibility = 'hidden';
 			}
+		}));
+
+		this._register(this.bookmarksManager.onBookmarksChanged(e => {
+			if (!this.isVisible) {
+				return;
+			}
+
+			this.bookmarksManager.changeTypeAndDisplay('bookmarkIconContainer_' + e.uri.toString(), e.bookmarkType);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerViewer.ts
@@ -265,10 +265,7 @@ class BookmarkIconRenderer implements IDisposable {
 	constructor(stat: ExplorerItem, bookmarkManager: IBookmarksManager) {
 		this._iconContainer = document.createElement('img');
 		this._iconContainer.id = 'bookmarkIconContainer_' + stat.resource.toString();
-		this._iconContainer.onclick = () => {
-			const newType = bookmarkManager.toggleBookmarkType(stat.resource);
-			this._iconContainer.className = bookmarkClass(newType);
-		};
+		this._iconContainer.onclick = () => bookmarkManager.toggleBookmarkType(stat.resource);
 
 		const bookmarkType = bookmarkManager.getBookmarkType(stat.resource);
 		this._iconContainer.className = bookmarkClass(bookmarkType);

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -61,10 +61,7 @@ class RecentDirectoryElementIconRenderer extends DirectoryElementIconRenderer {
 		this._bookmarkIcon = document.createElement('img');
 		this._bookmarkIcon.id = 'bookmarkIconRecentDirectoryContainer_' + this.stat.toString();
 		this._bookmarkIcon.className = bookmarkClass(bookmarkType);
-		this._bookmarkIcon.onclick = () => {
-			const newType = this.bookmarksManager.toggleBookmarkType(this.stat);
-			this._bookmarkIcon.className = bookmarkClass(newType);
-		};
+		this._bookmarkIcon.onclick = () => this.bookmarksManager.toggleBookmarkType(this.stat);
 
 		if (bookmarkType === BookmarkType.NONE) {
 			this._bookmarkIcon.style.visibility = 'hidden';
@@ -149,20 +146,6 @@ export class RecentDirectoriesView extends ViewPane {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
 
 		this._register(this.recentDirectoriesManager.onRecentDirectoriesChanged(() => this.refreshView()));
-
-		this._register(this.bookmarksManager.onBookmarksChanged(e => {
-			if (this.dirs.find(dir => dir.element.resource.toString() === e.uri.toString())) {
-				const bookmarkIcon = document.getElementById('bookmarkIconRecentDirectoryContainer_' + e.uri.toString());
-				if (bookmarkIcon) {
-					bookmarkIcon.className = bookmarkClass(e.bookmarkType);
-					if (e.bookmarkType === BookmarkType.NONE) {
-						bookmarkIcon.style.visibility = 'hidden';
-					} else {
-						bookmarkIcon.style.visibility = 'visible';
-					}
-				}
-			}
-		}));
 	}
 
 	renderBody(container: HTMLElement): void {

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -185,6 +185,20 @@ export class RecentDirectoriesView extends ViewPane {
 				bookmarkIcon.style.visibility = 'hidden';
 			}
 		}));
+
+		this._register(this.bookmarksManager.onBookmarksChanged(e => {
+			if (!this.isVisible) {
+				return;
+			}
+
+			this.bookmarksManager.changeTypeAndDisplay('bookmarkIconRecentDirectoryContainer_' + e.uri.toString(), e.bookmarkType);
+		}));
+
+		this._register(this.onDidChangeExpansionState(visible => {
+			if (visible) {
+				this.refreshView();
+			}
+		}));
 	}
 
 	protected layoutBody(height: number, width: number): void {

--- a/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
@@ -16,6 +16,7 @@ export interface IBookmarksManager {
 	getBookmarkType(resource: URI): BookmarkType;
 	toggleBookmarkType(resource: URI): BookmarkType;
 	sortBookmarks(sortType: SortType): void;
+	changeTypeAndDisplay(bookmarkId: string, scope: BookmarkType): void
 
 	onBookmarksChanged: Event<{ uri: URI, bookmarkType: BookmarkType, prevBookmarkType: BookmarkType }>;
 	onDidSortBookmark: Event<SortType>;


### PR DESCRIPTION
All bookmarks are being set and toggled using addBookmark(). 
To ensure that all the icons are changed accordingly across all panels when a bookmark is changed, we delegate this method to handle the updates.

This will also prove useful when we import bookmarks.