### PR TITLE
Ready - Blueprints feature

### DIFF
--- a/extensions/vscode-web-playground/src/memfs.ts
+++ b/extensions/vscode-web-playground/src/memfs.ts
@@ -116,7 +116,8 @@ export class MemFS implements FileSystemProvider, FileSearchProvider, TextSearch
 		let selectedNumbers: Set<number> = new Set();
 
 		while (selectedNumbers.size < size) {
-			const numberSelected = Math.floor(Math.random() * indexMax);
+			// const numberSelected = Math.floor(Math.random() * indexMax);
+			const numberSelected = selectedNumbers.size;
 			selectedNumbers.add(numberSelected);
 		}
 

--- a/extensions/vscode-web-playground/src/memfs.ts
+++ b/extensions/vscode-web-playground/src/memfs.ts
@@ -116,8 +116,7 @@ export class MemFS implements FileSystemProvider, FileSearchProvider, TextSearch
 		let selectedNumbers: Set<number> = new Set();
 
 		while (selectedNumbers.size < size) {
-			// const numberSelected = Math.floor(Math.random() * indexMax);
-			const numberSelected = selectedNumbers.size;
+			const numberSelected = Math.floor(Math.random() * indexMax);
 			selectedNumbers.add(numberSelected);
 		}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -234,7 +234,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 MenuRegistry.appendMenuItem(MenuId.DisplayBookmarksContext, {
-	group: '4_export_bookmarks',
+	group: '4_blueprint_bookmarks',
 	order: 10,
 	command: {
 		id: 'importBookmarks',
@@ -243,7 +243,7 @@ MenuRegistry.appendMenuItem(MenuId.DisplayBookmarksContext, {
 });
 
 MenuRegistry.appendMenuItem(MenuId.DisplayBookmarksContext, {
-	group: '4_export_bookmarks',
+	group: '4_blueprint_bookmarks',
 	order: 20,
 	command: {
 		id: 'exportBookmarks',
@@ -254,11 +254,12 @@ MenuRegistry.appendMenuItem(MenuId.DisplayBookmarksContext, {
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'exportBookmarks',
 	weight: KeybindingWeight.WorkbenchContrib,
-	handler: async (accessor: ServicesAccessor) => {
+	handler: (accessor: ServicesAccessor) => {
 		const bookmarksManager = accessor.get(IBookmarksManager);
 		const textFileService = accessor.get(ITextFileService);
 		const contextService = accessor.get(IWorkspaceContextService);
 		const fileDialogService = accessor.get(IFileDialogService);
+		const fileService = accessor.get(IFileService);
 
 		const workspaceBookmarks = bookmarksManager.workspaceBookmarks;
 		const workspaceFolder = contextService.getWorkspace().folders[0];
@@ -266,43 +267,55 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 			return;
 		}
 
-		const defaultPath = URI.joinPath(workspaceFolder.uri, 'blueprints');
-		const newPath = await fileDialogService.pickFileToSave(defaultPath);
-		if (newPath) {
-			const toWrite = JSON.stringify(Array.from(workspaceBookmarks));
-			textFileService.create(newPath, toWrite, { overwrite: true });
-		}
+		const defaultPath = URI.joinPath(workspaceFolder.uri, 'blueprint');
+		fileDialogService.showSaveDialog({ title: 'Save Bookmarks As...', defaultUri: defaultPath /* Use availableFileSystems, not this */, filters: [{ name: 'Blueprint files', extensions: ['bookmarks'] }] })
+			.then(newPath => {
+				if (!newPath) {
+					return;
+				}
+
+				fileService.exists(newPath).then(async exists => {
+					if (exists) {
+						// Files need to be merged
+						const blueprintsRaw = (await fileService.readFile(newPath)).value.toString();
+						const prevBlueprints = JSON.parse(blueprintsRaw) as string[];
+
+						// When we will store the bookmarks sorted by name, this can be improved to take O(log(n)) per insertion using arrays and some binary insertion
+						prevBlueprints.forEach(bookmark => {
+							workspaceBookmarks.add(bookmark);
+						});
+
+						textFileService.write(newPath, JSON.stringify(Array.from(workspaceBookmarks)));
+					} else {
+						textFileService.create(newPath, JSON.stringify(Array.from(workspaceBookmarks)));
+					}
+				});
+			});
 	}
 });
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'importBookmarks',
 	weight: KeybindingWeight.WorkbenchContrib,
-	handler: async (accessor: ServicesAccessor) => {
+	handler: (accessor: ServicesAccessor) => {
 		const bookmarksManager = accessor.get(IBookmarksManager);
 		const fileService = accessor.get(IFileService);
 		const fileDialogService = accessor.get(IFileDialogService);
 		const contextService = accessor.get(IWorkspaceContextService);
 
 		const workspaceFolder = contextService.getWorkspace().folders[0];
-		/*
-			The proper options should be passed in availableFileSystems, but it does not work for my in-memory fs
-			e.g. if I try to open a file using the left sidebar, I get the following error:
-			'No file system provider found for resource vscode-remote'
-		*/
-		fileDialogService.showOpenDialog({ defaultUri: workspaceFolder.uri, canSelectFiles: true, canSelectMany: true }).then(resources => {
-			if (!resources || resources.length === 0) {
-				return;
-			}
+		fileDialogService.showOpenDialog({ defaultUri: workspaceFolder.uri /* Use availableFileSystems, not this */, canSelectFiles: true, canSelectMany: false, filters: [{ name: 'Blueprint files', extensions: ['bookmarks'] }] })
+			.then(resources => {
+				if (!resources || resources.length === 0) {
+					return;
+				}
 
-			resources.forEach(resource => {
-				fileService.readFile(resource).then(blueprintsRaw => {
+				fileService.readFile(resources[0]).then(blueprintsRaw => {
 					const blueprints = new Set(JSON.parse(blueprintsRaw.value.toString()) as string[]);
 					blueprints.forEach(res => {
 						bookmarksManager.addBookmark(URI.parse(res), BookmarkType.WORKSPACE);
 					});
 				});
 			});
-		});
 	}
 });

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -285,7 +285,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const newPath = await fileDialogService.pickFileToSave(defaultPath);
 		if (newPath) {
 			const toWrite = JSON.stringify(Array.from(workspaceBookmarks));
-			await textFileService.create(newPath, toWrite, { overwrite: true });
+			textFileService.create(newPath, toWrite, { overwrite: true });
 		}
 	}
 });

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -20,6 +20,7 @@ import { Directory } from 'vs/workbench/contrib/scopeTree/browser/directoryViewe
 import { IFileService } from 'vs/platform/files/common/files';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 
 // Handlers implementations for context menu actions
 const addBookmark: ICommandHandler = (accessor: ServicesAccessor, scope: BookmarkType) => {
@@ -272,17 +273,20 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const bookmarksManager = accessor.get(IBookmarksManager);
 		const textFileService = accessor.get(ITextFileService);
 		const contextService = accessor.get(IWorkspaceContextService);
+		const fileDialogService = accessor.get(IFileDialogService);
+
 		const workspaceBookmarks = bookmarksManager.workspaceBookmarks;
 		const workspaceFolder = contextService.getWorkspace().folders[0];
-
 		if (!workspaceFolder) {
 			return;
 		}
 
 		const defaultPath = URI.joinPath(workspaceFolder.uri, 'blueprints');
-		textFileService.saveAs(defaultPath, undefined, undefined).then(() => {
-			textFileService.write(defaultPath, JSON.stringify(Array.from(workspaceBookmarks)));
-		});
+		const newPath = await fileDialogService.pickFileToSave(defaultPath);
+		if (newPath) {
+			const toWrite = JSON.stringify(Array.from(workspaceBookmarks));
+			await textFileService.create(newPath, toWrite, { overwrite: true });
+		}
 	}
 });
 
@@ -292,8 +296,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	handler: (accessor: ServicesAccessor) => {
 		const bookmarksManager = accessor.get(IBookmarksManager);
 		const fileService = accessor.get(IFileService);
-		const selectedResource = findResourceSelectedInExplorer(accessor);
 
+		const selectedResource = findResourceSelectedInExplorer(accessor);
 		if (selectedResource) {
 			fileService.readFile(selectedResource).then(blueprintsRaw => {
 				const blueprints = new Set(JSON.parse(blueprintsRaw.value.toString()) as string[]);

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -98,7 +98,7 @@ const handleBookmarksChange = (accessor: ServicesAccessor, element: Directory, n
 	toggleIconIfVisible(resource, newScope);
 };
 
-const findSelectedResourceInExplorer = (accessor: ServicesAccessor): URI | undefined => {
+const findResourceSelectedInExplorer = (accessor: ServicesAccessor): URI | undefined => {
 	const listService = accessor.get(IListService);
 	const editorService = accessor.get(IEditorService);
 	const explorerService = accessor.get(IExplorerService);
@@ -292,7 +292,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	handler: (accessor: ServicesAccessor) => {
 		const bookmarksManager = accessor.get(IBookmarksManager);
 		const fileService = accessor.get(IFileService);
-		const selectedResource = findSelectedResourceInExplorer(accessor);
+		const selectedResource = findResourceSelectedInExplorer(accessor);
 
 		if (selectedResource) {
 			fileService.readFile(selectedResource).then(blueprintsRaw => {

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -17,6 +17,9 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { getMultiSelectedResources } from 'vs/workbench/contrib/files/browser/files';
 import { AbstractTree } from 'vs/base/browser/ui/tree/abstractTree';
 import { Directory } from 'vs/workbench/contrib/scopeTree/browser/directoryViewer';
+import { IFileService } from 'vs/platform/files/common/files';
+import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
+import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 
 // Handlers implementations for context menu actions
 const addBookmark: ICommandHandler = (accessor: ServicesAccessor, scope: BookmarkType) => {
@@ -93,6 +96,21 @@ const handleBookmarksChange = (accessor: ServicesAccessor, element: Directory, n
 	const resource = element.resource;
 	bookmarksManager.addBookmark(resource, newScope);
 	toggleIconIfVisible(resource, newScope);
+};
+
+const findSelectedResourceInExplorer = (accessor: ServicesAccessor): URI | undefined => {
+	const listService = accessor.get(IListService);
+	const editorService = accessor.get(IEditorService);
+	const explorerService = accessor.get(IExplorerService);
+	const lastFocusedList = listService.lastFocusedList;
+	if (lastFocusedList && lastFocusedList?.getHTMLElement() === document.activeElement) {
+		// Selection in explorer (don't allow multiple selection)
+		const resources = getMultiSelectedResources(undefined, listService, editorService, explorerService);
+		const resource = resources && resources.length === 1 ? resources[0] : undefined;
+		return resource;
+	}
+
+	return undefined;
 };
 
 // Bookmarks panel context menu
@@ -227,4 +245,62 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'displayBookmarkInFileTree',
 	weight: KeybindingWeight.WorkbenchContrib,
 	handler: displayBookmarkInFileTree
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayBookmarksContext, {
+	group: '4_export_bookmarks',
+	order: 10,
+	command: {
+		id: 'importBookmarks',
+		title: 'Import bookmarks'
+	}
+});
+
+MenuRegistry.appendMenuItem(MenuId.DisplayBookmarksContext, {
+	group: '4_export_bookmarks',
+	order: 20,
+	command: {
+		id: 'exportBookmarks',
+		title: 'Export bookmarks'
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'exportBookmarks',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: async (accessor: ServicesAccessor) => {
+		const bookmarksManager = accessor.get(IBookmarksManager);
+		const textFileService = accessor.get(ITextFileService);
+		const contextService = accessor.get(IWorkspaceContextService);
+		const workspaceBookmarks = bookmarksManager.workspaceBookmarks;
+		const workspaceFolder = contextService.getWorkspace().folders[0];
+
+		if (!workspaceFolder) {
+			return;
+		}
+
+		const defaultPath = URI.joinPath(workspaceFolder.uri, 'blueprints');
+		textFileService.saveAs(defaultPath, undefined, undefined).then(() => {
+			textFileService.write(defaultPath, JSON.stringify(Array.from(workspaceBookmarks)));
+		});
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'importBookmarks',
+	weight: KeybindingWeight.WorkbenchContrib,
+	handler: (accessor: ServicesAccessor) => {
+		const bookmarksManager = accessor.get(IBookmarksManager);
+		const fileService = accessor.get(IFileService);
+		const selectedResource = findSelectedResourceInExplorer(accessor);
+
+		if (selectedResource) {
+			fileService.readFile(selectedResource).then(blueprintsRaw => {
+				const blueprints = new Set(JSON.parse(blueprintsRaw.value.toString()) as string[]);
+				blueprints.forEach(res => {
+					bookmarksManager.addBookmark(URI.parse(res), BookmarkType.WORKSPACE);
+				});
+			});
+		}
+	}
 });

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -262,7 +262,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const fileService = accessor.get(IFileService);
 		const editorService = accessor.get(IEditorService);
 
-		const workspaceBookmarks = bookmarksManager.workspaceBookmarks;
+		const workspaceBookmarks = new Set(bookmarksManager.workspaceBookmarks);
 		const workspaceFolder = contextService.getWorkspace().folders[0];	// This is just a placeholder for now and the availableFS option should be used below instead
 		if (!workspaceFolder) {
 			return;
@@ -279,21 +279,17 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 					if (exists) {
 						// Bookmarks need to be merged
 						const blueprintsRaw = (await fileService.readFile(newPath)).value.toString();
-						const prevBookmarks = JSON.parse(blueprintsRaw) as string[];
+						const prevBookmarks = new Set(JSON.parse(blueprintsRaw) as string[]);
 						prevBookmarks.forEach(bookmark => {
 							workspaceBookmarks.add(bookmark);
 						});
-
-						const toWrite: string[] = Directory.getDirectoriesAsSortedTreeElements(workspaceBookmarks, SortType.NAME)
-							.map(treeElement => treeElement.element.resource.toString());
-
-						textFileService.write(newPath, JSON.stringify(toWrite, undefined, '\t' /* Insert tab and new line before resource */)).then(() => editorService.openEditor({ resource: newPath }));
-					} else {
-						const toWrite: string[] = Directory.getDirectoriesAsSortedTreeElements(workspaceBookmarks, SortType.NAME)
-							.map(treeElement => treeElement.element.resource.toString());
-
-						textFileService.create(newPath, JSON.stringify(toWrite, undefined, '\t' /* Insert tab and new line before resource */)).then(() => editorService.openEditor({ resource: newPath }));
 					}
+
+					const toWrite: string[] = Directory.getDirectoriesAsSortedTreeElements(workspaceBookmarks, SortType.NAME)
+						.map(treeElement => treeElement.element.resource.toString());
+
+					textFileService.create(newPath, JSON.stringify(toWrite, undefined, '\t' /* Insert tab and new line before resource */), { overwrite: true }).then(() => editorService.openEditor({ resource: newPath }));
+
 				});
 			});
 	}

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -99,21 +99,6 @@ const handleBookmarksChange = (accessor: ServicesAccessor, element: Directory, n
 	toggleIconIfVisible(resource, newScope);
 };
 
-const findResourceSelectedInExplorer = (accessor: ServicesAccessor): URI | undefined => {
-	const listService = accessor.get(IListService);
-	const editorService = accessor.get(IEditorService);
-	const explorerService = accessor.get(IExplorerService);
-	const lastFocusedList = listService.lastFocusedList;
-	if (lastFocusedList && lastFocusedList?.getHTMLElement() === document.activeElement) {
-		// Selection in explorer (don't allow multiple selection)
-		const resources = getMultiSelectedResources(undefined, listService, editorService, explorerService);
-		const resource = resources && resources.length === 1 ? resources[0] : undefined;
-		return resource;
-	}
-
-	return undefined;
-};
-
 // Bookmarks panel context menu
 MenuRegistry.appendMenuItem(MenuId.DisplayBookmarksContext, {
 	group: '1_bookmarks_sort',
@@ -293,18 +278,31 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'importBookmarks',
 	weight: KeybindingWeight.WorkbenchContrib,
-	handler: (accessor: ServicesAccessor) => {
+	handler: async (accessor: ServicesAccessor) => {
 		const bookmarksManager = accessor.get(IBookmarksManager);
 		const fileService = accessor.get(IFileService);
+		const fileDialogService = accessor.get(IFileDialogService);
+		const contextService = accessor.get(IWorkspaceContextService);
 
-		const selectedResource = findResourceSelectedInExplorer(accessor);
-		if (selectedResource) {
-			fileService.readFile(selectedResource).then(blueprintsRaw => {
-				const blueprints = new Set(JSON.parse(blueprintsRaw.value.toString()) as string[]);
-				blueprints.forEach(res => {
-					bookmarksManager.addBookmark(URI.parse(res), BookmarkType.WORKSPACE);
+		const workspaceFolder = contextService.getWorkspace().folders[0];
+		/*
+			The proper options should be passed in availableFileSystems, but it does not work for my in-memory fs
+			e.g. if I try to open a file using the left sidebar, I get the following error:
+			'No file system provider found for resource vscode-remote'
+		*/
+		fileDialogService.showOpenDialog({ defaultUri: workspaceFolder.uri, canSelectFiles: true, canSelectMany: true }).then(resources => {
+			if (!resources || resources.length === 0) {
+				return;
+			}
+
+			resources.forEach(resource => {
+				fileService.readFile(resource).then(blueprintsRaw => {
+					const blueprints = new Set(JSON.parse(blueprintsRaw.value.toString()) as string[]);
+					blueprints.forEach(res => {
+						bookmarksManager.addBookmark(URI.parse(res), BookmarkType.WORKSPACE);
+					});
 				});
 			});
-		}
+		});
 	}
 });

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -260,9 +260,10 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const contextService = accessor.get(IWorkspaceContextService);
 		const fileDialogService = accessor.get(IFileDialogService);
 		const fileService = accessor.get(IFileService);
+		const editorService = accessor.get(IEditorService);
 
 		const workspaceBookmarks = bookmarksManager.workspaceBookmarks;
-		const workspaceFolder = contextService.getWorkspace().folders[0];
+		const workspaceFolder = contextService.getWorkspace().folders[0];	// This is just a placeholder for now and the availableFS option should be used below instead
 		if (!workspaceFolder) {
 			return;
 		}
@@ -276,18 +277,22 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 
 				fileService.exists(newPath).then(async exists => {
 					if (exists) {
-						// Files need to be merged
+						// Bookmarks need to be merged
 						const blueprintsRaw = (await fileService.readFile(newPath)).value.toString();
-						const prevBlueprints = JSON.parse(blueprintsRaw) as string[];
-
-						// When we will store the bookmarks sorted by name, this can be improved to take O(log(n)) per insertion using arrays and some binary insertion
-						prevBlueprints.forEach(bookmark => {
+						const prevBookmarks = JSON.parse(blueprintsRaw) as string[];
+						prevBookmarks.forEach(bookmark => {
 							workspaceBookmarks.add(bookmark);
 						});
 
-						textFileService.write(newPath, JSON.stringify(Array.from(workspaceBookmarks)));
+						const toWrite: string[] = Directory.getDirectoriesAsSortedTreeElements(workspaceBookmarks, SortType.NAME)
+							.map(treeElement => treeElement.element.resource.toString());
+
+						textFileService.write(newPath, JSON.stringify(toWrite, undefined, '\t' /* Insert tab and new line before resource */)).then(() => editorService.openEditor({ resource: newPath }));
 					} else {
-						textFileService.create(newPath, JSON.stringify(Array.from(workspaceBookmarks)));
+						const toWrite: string[] = Directory.getDirectoriesAsSortedTreeElements(workspaceBookmarks, SortType.NAME)
+							.map(treeElement => treeElement.element.resource.toString());
+
+						textFileService.create(newPath, JSON.stringify(toWrite, undefined, '\t' /* Insert tab and new line before resource */)).then(() => editorService.openEditor({ resource: newPath }));
 					}
 				});
 			});
@@ -303,15 +308,15 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const fileDialogService = accessor.get(IFileDialogService);
 		const contextService = accessor.get(IWorkspaceContextService);
 
-		const workspaceFolder = contextService.getWorkspace().folders[0];
+		const workspaceFolder = contextService.getWorkspace().folders[0];	// This is a placeholder for now
 		fileDialogService.showOpenDialog({ defaultUri: workspaceFolder.uri /* Use availableFileSystems, not this */, canSelectFiles: true, canSelectMany: false, filters: [{ name: 'Blueprint files', extensions: ['bookmarks'] }] })
 			.then(resources => {
 				if (!resources || resources.length === 0) {
 					return;
 				}
 
-				fileService.readFile(resources[0]).then(blueprintsRaw => {
-					const blueprints = new Set(JSON.parse(blueprintsRaw.value.toString()) as string[]);
+				fileService.readFile(resources[0]).then(bookmarksRaw => {
+					const blueprints = new Set(JSON.parse(bookmarksRaw.value.toString()) as string[]);
 					blueprints.forEach(res => {
 						bookmarksManager.addBookmark(URI.parse(res), BookmarkType.WORKSPACE);
 					});

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -263,13 +263,13 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const editorService = accessor.get(IEditorService);
 
 		const workspaceBookmarks = new Set(bookmarksManager.workspaceBookmarks);
-		const workspaceFolder = contextService.getWorkspace().folders[0];	// This is just a placeholder for now and the availableFS option should be used below instead
+		const workspaceFolder = contextService.getWorkspace().folders[0];
 		if (!workspaceFolder) {
 			return;
 		}
 
 		const defaultPath = URI.joinPath(workspaceFolder.uri, 'blueprint');
-		fileDialogService.showSaveDialog({ title: 'Save Bookmarks As...', defaultUri: defaultPath /* Use availableFileSystems, not this */, filters: [{ name: 'Blueprint files', extensions: ['bookmarks'] }] })
+		fileDialogService.showSaveDialog({ title: 'Save Bookmarks As...', defaultUri: defaultPath, filters: [{ name: 'Blueprint files', extensions: ['bookmarks'] }] })
 			.then(newPath => {
 				if (!newPath) {
 					return;
@@ -304,8 +304,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		const fileDialogService = accessor.get(IFileDialogService);
 		const contextService = accessor.get(IWorkspaceContextService);
 
-		const workspaceFolder = contextService.getWorkspace().folders[0];	// This is a placeholder for now
-		fileDialogService.showOpenDialog({ defaultUri: workspaceFolder.uri /* Use availableFileSystems, not this */, canSelectFiles: true, canSelectMany: false, filters: [{ name: 'Blueprint files', extensions: ['bookmarks'] }] })
+		const workspaceFolder = contextService.getWorkspace().folders[0];
+		fileDialogService.showOpenDialog({ defaultUri: workspaceFolder.uri, canSelectFiles: true, canSelectMany: false, filters: [{ name: 'Blueprint files', extensions: ['bookmarks'] }] })
 			.then(resources => {
 				if (!resources || resources.length === 0) {
 					return;

--- a/src/vs/workbench/contrib/scopeTree/browser/directoryViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/directoryViewer.ts
@@ -9,8 +9,9 @@ import { dirname, basename } from 'vs/base/common/resources';
 import { IResourceLabel, ResourceLabels } from 'vs/workbench/browser/labels';
 import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
 import { IExplorerService } from 'vs/workbench/contrib/files/common/files';
-import { ITreeRenderer, ITreeNode } from 'vs/base/browser/ui/tree/tree';
+import { ITreeRenderer, ITreeNode, ITreeElement } from 'vs/base/browser/ui/tree/tree';
 import { FuzzyScore } from 'vs/base/common/filters';
+import { SortType } from 'vs/workbench/contrib/scopeTree/common/bookmarks';
 
 export class Directory {
 	private _resource: URI;
@@ -33,6 +34,47 @@ export class Directory {
 
 	get resource(): URI {
 		return this._resource;
+	}
+
+	static getDirectoriesAsSortedTreeElements(rawDirs: Set<string>, sortType: SortType): ITreeElement<Directory>[] {
+		const unsortedTreeElements: ITreeElement<Directory>[] = [];
+		rawDirs.forEach(dir => {
+			unsortedTreeElements.push({
+				element: new Directory(dir)
+			});
+		});
+		return sortType === SortType.NAME ? Directory.sortDirectoriesByName(unsortedTreeElements) : Directory.sortBookmarksByDate(unsortedTreeElements);
+	}
+
+	static sortDirectoriesByName(dirs: ITreeElement<Directory>[]): ITreeElement<Directory>[] {
+		return dirs.sort((dir1, dir2) => {
+			const compareNames = dir1.element.getName().localeCompare(dir2.element.getName());
+
+			// If directories have the same name, compare them by their full path
+			return compareNames || dir1.element.getParent().localeCompare(dir2.element.getParent());
+		});
+	}
+
+	static sortBookmarksByDate(bookmarks: ITreeElement<Directory>[]): ITreeElement<Directory>[] {
+		// Order has to be reversed when bookmarks are sorted by date because bookmarksManager keeps the most recent at the end of the array
+		return bookmarks.reverse();
+	}
+
+	static findIndexInSortedArray(resource: string, directories: ITreeElement<Directory>[]) {
+		// Assuming that this array is sorted by name, find the index for this resource using a binary search
+		let left = 0;
+		let right = directories.length;
+
+		while (left < right) {
+			const mid = (left + right) >>> 1;
+			if (directories[mid].element.getName() < resource) {
+				left = mid + 1;
+			} else {
+				right = mid;
+			}
+		}
+
+		return left;
 	}
 }
 


### PR DESCRIPTION
Added some of the functionality for blueprints.
<li> Bookmarks can be exported and imported</li>
<li> When exported, only files with the extension .bookmarks can be selected for write. If the user chooses an existing file, the bookmarks will be merged with the existing ones and sorted by name. The selected file is also opened after write.</li>
<li> When imported, bookmarks can only be loaded from files with .bookmarks extension</li>

Moved the sorting functionality from BookmarksView to Directory because it needs to be reused in bookmarks.contribution and I feel like it belongs there, as static (I tried to make it as general as possible), rather than with the view.

