### PR TITLE
Ready - Move bookmarks to the right in recent directories panel

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/directoryViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/directoryViewer.ts
@@ -43,7 +43,7 @@ export interface IDirectoryTemplateData {
 }
 
 export class DirectoryElementIconRenderer implements IDisposable {
-	private _focusIcon!: HTMLElement;
+	protected _focusIcon!: HTMLElement;
 
 	constructor(protected readonly container: HTMLElement,
 		protected readonly stat: URI,

--- a/src/vs/workbench/contrib/scopeTree/browser/media/bookmarkIcon.css
+++ b/src/vs/workbench/contrib/scopeTree/browser/media/bookmarkIcon.css
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 .bookmark-not-set{
 	content: url('bookmark-not-set.svg');
-	padding-right: 5px;
 	padding-bottom: 2px;
 	object-fit: contain;
 }
@@ -12,14 +11,12 @@
 .bookmark-set-global{
 	content: url('bookmark-set-global.svg');
 	padding-bottom: 2px;
-	padding-right: 5px;
 	object-fit: contain;
 }
 
 .bookmark-set-workspace{
 	content: url('bookmark-set-workspace.svg');
 	padding-bottom: 2px;
-	padding-right: 5px;
 	object-fit: contain;
 }
 

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -49,6 +49,8 @@ class RecentDirectoryElementIconRenderer extends DirectoryElementIconRenderer {
 		explorerService: IExplorerService,
 		private readonly bookmarksManager: IBookmarksManager) {
 		super(container, stat, explorerService);
+		this._focusIcon.style.paddingLeft = '5px';
+
 		this.renderBookmarkIcon();
 	}
 
@@ -65,14 +67,13 @@ class RecentDirectoryElementIconRenderer extends DirectoryElementIconRenderer {
 			const newType = this.bookmarksManager.toggleBookmarkType(this.stat);
 			this._bookmarkIcon.className = bookmarkClass(newType);
 		};
+		this._bookmarkIcon.style.paddingRight = '10px';
 
 		if (bookmarkType === BookmarkType.NONE) {
 			this._bookmarkIcon.style.visibility = 'hidden';
 		}
 
-		if (this.container.firstChild) {
-			this.container.insertBefore(this._bookmarkIcon, this.container.firstChild?.nextSibling);
-		}
+		this.container.appendChild(this._bookmarkIcon);
 	}
 
 	dispose(): void {


### PR DESCRIPTION
Alberto thinks it would be better to move the bookmark icons in recent directories to the right (similarly to how they are rendered in the main file tree) for consistency.