### PR TITLE
Render strikethrough for workspace bookmarks that have been deleted or do not exist in workspace

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -385,6 +385,8 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 						bookmarksManager.addBookmark(URI.parse(res), BookmarkType.WORKSPACE);
 					});
 				});
+
+				bookmarksManager.sortBookmarks(bookmarksManager.sortType);
 			});
 	}
 });

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
@@ -17,6 +17,8 @@ export class BookmarksManager implements IBookmarksManager {
 	globalBookmarks: Set<string> = new Set();
 	workspaceBookmarks: Set<string> = new Set();
 
+	sortType: SortType = SortType.NAME;
+
 	private _onBookmarksChanged = new Emitter<{ uri: URI, bookmarkType: BookmarkType, prevBookmarkType: BookmarkType }>();
 	public onBookmarksChanged = this._onBookmarksChanged.event;
 
@@ -90,6 +92,7 @@ export class BookmarksManager implements IBookmarksManager {
 	}
 
 	public sortBookmarks(sortType: SortType) {
+		this.sortType = sortType;
 		this._onDidSortBookmark.fire(sortType);
 	}
 

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -31,6 +31,7 @@ import { IAction } from 'vs/base/common/actions';
 import { createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IMenu, IMenuService, MenuId } from 'vs/platform/actions/common/actions';
 import { Directory, IDirectoryTemplateData, DirectoryElementIconRenderer, DirectoryRenderer } from 'vs/workbench/contrib/scopeTree/browser/directoryViewer';
+import { IFileService } from 'vs/platform/files/common/files';
 
 export class BookmarkHeader {
 	expanded: boolean = true;
@@ -77,7 +78,9 @@ class BookmarkRenderer extends DirectoryRenderer {
 			name: bookmark.getName(),
 			description: bookmark.getParent()
 		}, {
-			matches: createMatches(filterData)
+			matches: createMatches(filterData),
+			strikethrough: !bookmark.exists,
+			title: bookmark.exists ? undefined : 'Does not exist'
 		});
 
 		return new DirectoryElementIconRenderer(templateData.label.element, bookmark.resource, this.explorerService);
@@ -159,6 +162,7 @@ export class BookmarksView extends ViewPane {
 	private contributedContextMenu!: IMenu;
 
 	private sortType: SortType = SortType.NAME;
+	private dirty: boolean = false;
 
 	constructor(
 		options: IViewletViewOptions,
@@ -174,6 +178,7 @@ export class BookmarksView extends ViewPane {
 		@IBookmarksManager private readonly bookmarksManager: IBookmarksManager,
 		@IExplorerService private readonly explorerService: IExplorerService,
 		@IMenuService private readonly menuService: IMenuService,
+		@IFileService private readonly fileService: IFileService
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
 
@@ -191,7 +196,15 @@ export class BookmarksView extends ViewPane {
 
 		this._register(this.bookmarksManager.onDidSortBookmark(sortType => {
 			this.sortType = sortType;
-			this.sortAndRefresh(sortType);
+			this.markDirty();
+		}));
+
+		this._register(this.fileService.onDidFilesChange(e => {
+			const deleted = e.getDeleted().filter(file => this.workspaceBookmarks.find(bookmark => bookmark.element.resource.toString() === file.resource.toString()));
+			const added = e.getAdded().filter(file => this.workspaceBookmarks.find(bookmark => bookmark.element.resource.toString() === file.resource.toString()));
+			if (added.length > 0 || deleted.length > 0) {
+				this.markDirty();
+			}
 		}));
 	}
 
@@ -202,7 +215,7 @@ export class BookmarksView extends ViewPane {
 		this._register(this.tree);
 
 		this.tree.setChildren(null, [{ element: this.globalBookmarksHeader }, { element: this.workspaceBookmarksHeader }]);
-		this.sortAndRefresh(this.sortType);
+		this.markDirty();
 
 		this._register(this.tree.onMouseClick(e => {
 			if (e.element instanceof BookmarkHeader) {
@@ -219,9 +232,18 @@ export class BookmarksView extends ViewPane {
 		this.tree.layout(height, width);
 	}
 
-	private sortAndRefresh(sortType: SortType) {
+	private async sortAndRefresh(sortType: SortType) {
+		if (!this.dirty) {
+			return;
+		}
+		this.dirty = false;
+
 		this.globalBookmarks = Directory.getDirectoriesAsSortedTreeElements(this.bookmarksManager.globalBookmarks, sortType);
 		this.workspaceBookmarks = Directory.getDirectoriesAsSortedTreeElements(this.bookmarksManager.workspaceBookmarks, sortType);
+
+		for (let bookmark of this.workspaceBookmarks) {
+			bookmark.element.exists = await this.fileService.exists(bookmark.element.resource);
+		}
 
 		this.tree.setChildren(this.globalBookmarksHeader, this.globalBookmarks);
 		this.tree.setChildren(this.workspaceBookmarksHeader, this.workspaceBookmarks);
@@ -318,6 +340,13 @@ export class BookmarksView extends ViewPane {
 			if (this.globalBookmarksHeader.expanded) {
 				this.tree.setChildren(this.globalBookmarksHeader, this.globalBookmarks);
 			}
+		}
+	}
+
+	private markDirty() {
+		if (!this.dirty) {
+			this.dirty = true;
+			setTimeout(() => this.sortAndRefresh(this.sortType), 100);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
@@ -11,6 +11,7 @@ export interface IBookmarksManager {
 	readonly _serviceBrand: undefined;
 	readonly globalBookmarks: Set<string>;
 	readonly workspaceBookmarks: Set<string>;
+	sortType: SortType;
 
 	addBookmark(resource: URI, scope: BookmarkType): void;
 	getBookmarkType(resource: URI): BookmarkType;


### PR DESCRIPTION
Render a strikethrough for workspace bookmarks that have been deleted (especially helpful when importing bookmarks).

To avoid unnecessary refresh, use the same flag as in recent directories implementation so that multiple calls to sortAndRefresh() are accumulated and delayed a little.