### PR TITLE
Show directory in the main file tree, from any panel, on 'enter' and double click

### DIFF
--- a/src/vs/workbench/contrib/files/common/explorerService.ts
+++ b/src/vs/workbench/contrib/files/common/explorerService.ts
@@ -77,6 +77,10 @@ export class ExplorerService implements IExplorerService {
 			}
 		}));
 	}
+	selectOrSetRoot(resource: URI): void {
+		throw new Error('Method not implemented.');
+	}
+
 	setRoot(resource: URI, selectResource?: URI | undefined): void {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -57,6 +57,7 @@ export interface IExplorerService {
 	 * Will try to resolve the path in case the explorer is not yet expanded to the file yet.
 	 */
 	select(resource: URI, reveal?: boolean | string): Promise<void>;
+	selectOrSetRoot(resource: URI): void;
 
 	registerView(contextAndRefreshProvider: IExplorerView): void;
 }

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -20,7 +20,7 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IFileDialogService, IDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { isEqualOrParent, dirname } from 'vs/base/common/resources';
+import { dirname } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import Severity from 'vs/base/common/severity';
 
@@ -81,14 +81,10 @@ const sortBookmarksByDate: ICommandHandler = (accessor: ServicesAccessor) => {
 const displayBookmarkInFileTree: ICommandHandler = (accessor: ServicesAccessor, element: Directory | BookmarkHeader) => {
 	if (element && element instanceof Directory) {
 		const explorerService = accessor.get(IExplorerService);
-		const rootResource = explorerService.roots[0].resource;
 		const selectedResource = element.resource;
 
-		const isChildOfCurrentRoot = isEqualOrParent(selectedResource, rootResource);
-		if (isChildOfCurrentRoot) {
-			explorerService.select(selectedResource);
-		} else {
-			explorerService.setRoot(selectedResource);
+		if (element.exists) {
+			explorerService.selectOrSetRoot(selectedResource);
 		}
 	}
 };

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksView.ts
@@ -223,8 +223,29 @@ export class BookmarksView extends ViewPane {
 			}
 		}));
 
+		this._register(this.tree.onMouseDblClick(e => {
+			const dir = e.element;
+			if (dir instanceof Directory && dir.exists) {
+				this.explorerService.selectOrSetRoot(dir.resource);
+			}
+		}));
+
 		this.contributedContextMenu = this.menuService.createMenu(MenuId.DisplayBookmarksContext, this.tree.contextKeyService);
 		this.tree.onContextMenu(e => this.onContextMenu(e));
+
+		this._register(this.tree.onKeyDown(e => {
+			if (e.key !== 'Enter') {
+				return;
+			}
+
+			const selection = this.tree.getSelection();
+			if (selection.length === 1) {
+				const dir = selection[0];
+				if (dir instanceof Directory && dir.exists) {
+					this.explorerService.selectOrSetRoot(dir.resource);
+				}
+			}
+		}));
 	}
 
 	protected layoutBody(height: number, width: number): void {

--- a/src/vs/workbench/contrib/scopeTree/browser/directoryViewer.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/directoryViewer.ts
@@ -107,10 +107,6 @@ export class DirectoryElementIconRenderer implements IDisposable {
 		this._focusIcon.style.visibility = 'hidden';
 	};
 
-	private select = async () => {
-		await this.explorerService.select(this.stat, true);	// Should also expand directory
-	};
-
 	private setRoot = () => {
 		this.explorerService.setRoot(this.stat);
 	};
@@ -118,7 +114,6 @@ export class DirectoryElementIconRenderer implements IDisposable {
 	private addListeners(): void {
 		this.container.addEventListener('mouseover', this.showIcon);
 		this.container.addEventListener('mouseout', this.hideIcon);
-		this.container.addEventListener('dblclick', this.select);
 		this._focusIcon.addEventListener('click', this.setRoot);
 	}
 
@@ -133,7 +128,6 @@ export class DirectoryElementIconRenderer implements IDisposable {
 		// Listeners need to be removed because container (templateData.label.element) is not removed from the DOM.
 		this.container.removeEventListener('mouseover', this.showIcon);
 		this.container.removeEventListener('mouseout', this.hideIcon);
-		this.container.removeEventListener('dblclick', this.select);
 		this._focusIcon.removeEventListener('click', this.setRoot);
 	}
 }

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -263,8 +263,8 @@ export class RecentDirectoriesView extends ViewPane {
 	private async getDirectoriesTreeElement(rawDirs: Set<string>): Promise<void> {
 		this.dirs = [];
 		for (let path of rawDirs) {
-			/* Quick fix for demo, to be deleted afterwards */
-			if (URI.parse(path).scheme === 'file' || URI.parse(path).scheme === 'memfs') {
+			const scheme = URI.parse(path).scheme;
+			if (scheme === 'file' || scheme === 'memfs') {
 				const element = new Directory(path);
 				element.exists = await this.fileService.exists(element.resource);
 

--- a/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/recentDirectoriesView.ts
@@ -210,6 +210,27 @@ export class RecentDirectoriesView extends ViewPane {
 			}
 		}));
 
+		this._register(this.tree.onKeyDown(e => {
+			if (e.key !== 'Enter') {
+				return;
+			}
+
+			const selection = this.tree.getSelection();
+			if (selection.length === 1) {
+				const dir = selection[0];
+				if (dir && dir.exists) {
+					this.explorerService.selectOrSetRoot(dir.resource);
+				}
+			}
+		}));
+
+		this._register(this.tree.onMouseDblClick(e => {
+			const dir = e.element;
+			if (dir && dir.exists) {
+				this.explorerService.selectOrSetRoot(dir.resource);
+			}
+		}));
+
 		this._register(this.bookmarksManager.onBookmarksChanged(e => {
 			if (!this.isVisible) {
 				return;
@@ -242,12 +263,15 @@ export class RecentDirectoriesView extends ViewPane {
 	private async getDirectoriesTreeElement(rawDirs: Set<string>): Promise<void> {
 		this.dirs = [];
 		for (let path of rawDirs) {
-			const element = new Directory(path);
-			element.exists = await this.fileService.exists(element.resource);
+			/* Quick fix for demo, to be deleted afterwards */
+			if (URI.parse(path).scheme === 'file' || URI.parse(path).scheme === 'memfs') {
+				const element = new Directory(path);
+				element.exists = await this.fileService.exists(element.resource);
 
-			this.dirs.push({
-				element: element
-			});
+				this.dirs.push({
+					element: element
+				});
+			}
 		}
 		this.dirs.reverse();
 	}

--- a/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/explorerService.ts
@@ -11,7 +11,7 @@ import { ExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
 import { ExplorerModel } from 'vs/workbench/contrib/scopeTree/common/explorerModel';
 import { URI } from 'vs/base/common/uri';
 import { FileOperationEvent, FileOperation, IFileService, FileChangesEvent, FILES_EXCLUDE_CONFIG, FileChangeType, IResolveFileOptions } from 'vs/platform/files/common/files';
-import { dirname } from 'vs/base/common/resources';
+import { dirname, isEqualOrParent } from 'vs/base/common/resources';
 import { memoize } from 'vs/base/common/decorators';
 import { ResourceGlobMatcher } from 'vs/workbench/common/resources';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -151,6 +151,19 @@ export class ExplorerService implements IExplorerService {
 				}
 				this._onDidChangeRoot.fire();
 			}));
+	}
+
+	selectOrSetRoot(resource: URI): void {
+		if (this.roots.length === 0) {
+			return;
+		}
+
+		const root = this.roots[0];
+		if (isEqualOrParent(resource, root.resource)) {
+			this.select(resource);
+		} else {
+			this.setRoot(resource);
+		}
 	}
 
 	getEditable(): { stat: ExplorerItem, data: IEditableData } | undefined {


### PR DESCRIPTION
Add a method to explorerService that selects a file in the file tree and, if that is not possible because the resource does not exist under the current root, sets it as root.

This method is triggered by 'enter' in any of the bookmarks / recent directories panel, and also on double click.