### PR TITLE
Rename addBookmark() method to avoid confusion when removing a bookmark

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarks.contribution.ts
@@ -31,7 +31,7 @@ const addBookmark: ICommandHandler = (accessor: ServicesAccessor, scope: Bookmar
 	const stats = explorerService.getContext(/*respectMultiSelection = */ true);
 
 	for (let stat of stats) {
-		bookmarksManager.addBookmark(stat.resource, scope);
+		bookmarksManager.setBookmark(stat.resource, scope);
 	}
 };
 
@@ -92,7 +92,7 @@ const displayBookmarkInFileTree: ICommandHandler = (accessor: ServicesAccessor, 
 const handleBookmarksChange = (accessor: ServicesAccessor, element: Directory, newScope: BookmarkType) => {
 	const bookmarksManager = accessor.get(IBookmarksManager);
 	const resource = element.resource;
-	bookmarksManager.addBookmark(resource, newScope);
+	bookmarksManager.setBookmark(resource, newScope);
 };
 
 // Bookmarks panel context menu
@@ -387,7 +387,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 					}
 
 					blueprints.forEach(res => {
-						bookmarksManager.addBookmark(URI.parse(res), BookmarkType.WORKSPACE);
+						bookmarksManager.setBookmark(URI.parse(res), BookmarkType.WORKSPACE);
 					});
 				});
 
@@ -411,7 +411,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 					const resource = URI.parse(bookmark);
 					const exists = await fileService.exists(resource);
 					if (!exists) {
-						bookmarksManager.addBookmark(resource, BookmarkType.NONE);	// Remove bookmark
+						bookmarksManager.setBookmark(resource, BookmarkType.NONE);	// Remove bookmark
 					}
 				}
 			}

--- a/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/bookmarksManager.ts
@@ -32,7 +32,7 @@ export class BookmarksManager implements IBookmarksManager {
 	}
 
 	// Preserve sorting by date when bookmarks are added to the sets (most recent is the last inserted)
-	public addBookmark(resource: URI, scope: BookmarkType): void {
+	public setBookmark(resource: URI, scope: BookmarkType): void {
 		const resourceAsString = resource.toString();
 		let prevScope = BookmarkType.NONE;	// Undefined if bookmark already had the appropriate type
 
@@ -86,7 +86,7 @@ export class BookmarksManager implements IBookmarksManager {
 
 	public toggleBookmarkType(resource: URI): BookmarkType {
 		const newType = (this.getBookmarkType(resource) + 1) % 3;
-		this.addBookmark(resource, newType);
+		this.setBookmark(resource, newType);
 
 		return newType;
 	}

--- a/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
+++ b/src/vs/workbench/contrib/scopeTree/common/bookmarks.ts
@@ -13,7 +13,7 @@ export interface IBookmarksManager {
 	readonly workspaceBookmarks: Set<string>;
 	sortType: SortType;
 
-	addBookmark(resource: URI, scope: BookmarkType): void;
+	setBookmark(resource: URI, scope: BookmarkType): void;
 	getBookmarkType(resource: URI): BookmarkType;
 	toggleBookmarkType(resource: URI): BookmarkType;
 	sortBookmarks(sortType: SortType): void;


### PR DESCRIPTION
Rename addBookmark() to setBookmark() so that there is no confusion when BookmarkType.NONE is used