### PR TITLE
Use implemented method to expand ancestors and select resource

### DIFF
--- a/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
+++ b/src/vs/workbench/contrib/scopeTree/browser/explorerView.ts
@@ -343,7 +343,7 @@ export class ExplorerView extends ViewPane {
 			if (!root || !isEqualOrParent(resource, root)) {
 				this.explorerService.setRoot(dirname(resource), resource);
 			} else {
-				this.expandAncestorsAndSelect(resource);
+				this.selectResource(resource, /* reveal */ true);
 			}
 		}));
 
@@ -829,41 +829,6 @@ export class ExplorerView extends ViewPane {
 
 		// check for files
 		return withNullAsUndefined(toResource(input, { supportSideBySide: SideBySideEditor.PRIMARY }));
-	}
-
-	private async expandAncestorsAndSelect(resource: URI): Promise<void> {
-		const ancestors: URI[] = [];
-		const treeInput = this.tree.getInput() as ExplorerItem;
-		const rootResource = treeInput.resource.toString();
-		let ancestor: URI = resource;
-
-		while (ancestor.toString() !== rootResource) {
-			ancestors.push(ancestor);
-			ancestor = dirname(ancestor);
-		}
-
-		ancestors.reverse();
-
-		let toExpand = treeInput;
-		for (let i = 0; i < ancestors.length; i++) {
-			const expandNext = toExpand.getChild(basename(ancestors[i]));
-			if (!expandNext) {
-				return;
-			}
-
-			await this.tree.expand(expandNext);
-			toExpand = expandNext;
-
-			const currentRoot = this.tree.getInput() as ExplorerItem;
-			if (rootResource !== currentRoot.resource.toString()) {
-				return;
-			}
-		}
-
-		const currentRoot = this.tree.getInput() as ExplorerItem;
-		if (rootResource === currentRoot.resource.toString()) {
-			this.selectResource(resource);
-		}
 	}
 
 	public async selectResource(resource: URI | undefined, reveal = this.autoReveal, retry = 0): Promise<void> {


### PR DESCRIPTION
expandAncestorsAndSelect() and selectResource() implement the same functionality, although there are some small differences, but I think it would be best to use selectResource() because it was pre implemented in the initial component.

There are nevertheless some differences:
   selectResource() does not explicitly check whether the root has changed. Nevertheless, if that happens and the file cannot be selected anymore the calls to tree.expand (line 886) will throw an exception and the selection is retried (unless the file still exists under the current root). We could also have additional checks for this in the while loop of selectResource().

   selectResource() finds the ancestors by starting at the root then going down until it finds the resource, so it is possible that it visits all directories in a branch before moving on to the next ancestor. I think our implementation which started at the resource then found the parents using dirname() would be more efficient.

   Previously (after expanding all directories) we were calling .selectResource() at the end of expandAncestorsAndSelect(). If we want to keep our method we can just replace that with this.tree.setSelection([resource]) so these redundant calls are not performed anymore.